### PR TITLE
added new stripe fields to vendor prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -418,6 +418,12 @@ model Vendor {
   address           String?
   businessHours     String?
   defaultOrderNotes String?
+
+  // Stripe Connect Integration (Phase 11)
+  stripeAccountId   String?         @unique // Stripe Connect account ID for receiving payments
+  chargesEnabled    Boolean         @default(false) // Whether the vendor can accept charges
+  payoutsEnabled    Boolean         @default(false) // Whether the vendor can receive payouts
+
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
   deletedAt         DateTime?


### PR DESCRIPTION
Description

This PR completes Issue #98 by extending the Vendor model with Stripe Connect–related fields required for Phase 11 vendor-side direct charges.

These changes prepare Hydra for Stripe Connect onboarding and payment execution while remaining backward-compatible and non-breaking for existing vendor flows.

No payment logic is introduced in this PR.

What’s Included
🧱 Schema Updates

prisma/schema.prisma (lines 422–425)

Added the following optional fields to the Vendor model:

stripeAccountId (String?, @unique)
Stores the Stripe Connect account ID for the vendor

chargesEnabled (Boolean, default: false)
Indicates whether the vendor can accept charges

payoutsEnabled (Boolean, default: false)
Indicates whether the vendor can receive payouts

All fields are nullable or have safe defaults.

🗄 Database Migration

Migration created:
20260102092344_add_stripe_connect_fields_to_vendor

Successfully applied to the database

Prisma Client regenerated with updated types

Verification

✅ Database schema updated successfully

✅ Prisma Client types reflect new fields

✅ No breaking changes to existing vendor flows

✅ Safe defaults prevent issues with existing records

Out of Scope (Intentional)

❌ Vendor Stripe onboarding flow

❌ Payment execution or authorization

❌ Payout logic

❌ Platform fee handling

These will be implemented in subsequent Phase 11 issues.

Related Issues

Closes #98

Prepares groundwork for:

#99 Vendor Stripe onboarding

#101 Vendor-side payment pre-authorization

#103 Payment capture after delivery

Notes for Reviewers

This PR is purely preparatory. It introduces no behavioral changes and does not activate Stripe Connect functionality yet. All payment execution remains deferred until later Phase 11 work.

🚦 Phase 11 Status Update

With this PR merged:

Vendor model is Stripe Connect–ready

No refactors required for upcoming onboarding and payment flows

Phase 11 work can proceed cleanly and incrementally