### PR TITLE
[N1.2] Add VAT snapshot fields to OrderItem/SubOrder + Vendor.priceIncludesVat

### DIFF
--- a/prisma/migrations/20260119000000_add_vat_snapshot_fields/migration.sql
+++ b/prisma/migrations/20260119000000_add_vat_snapshot_fields/migration.sql
@@ -1,0 +1,25 @@
+-- N1.2: Add VAT snapshot fields to OrderItem/SubOrder + Vendor.priceIncludesVat
+-- Issue: #120
+-- All new columns are nullable (except priceIncludesVat which has default)
+-- Existing orders remain unaffected with NULL values
+
+-- Vendor: Add priceIncludesVat flag (false = NET pricing, true = GROSS pricing)
+ALTER TABLE "Vendor" ADD COLUMN "priceIncludesVat" BOOLEAN NOT NULL DEFAULT false;
+
+-- SubOrder: Add VAT totals (captured at order time)
+ALTER TABLE "SubOrder" ADD COLUMN "netTotalCents" INTEGER;
+ALTER TABLE "SubOrder" ADD COLUMN "vatTotalCents" INTEGER;
+ALTER TABLE "SubOrder" ADD COLUMN "grossTotalCents" INTEGER;
+
+-- OrderItem: Add VAT snapshot fields
+ALTER TABLE "OrderItem" ADD COLUMN "taxProfileId" TEXT;
+ALTER TABLE "OrderItem" ADD COLUMN "vatRateBps" INTEGER;
+ALTER TABLE "OrderItem" ADD COLUMN "vatAmountCents" INTEGER;
+ALTER TABLE "OrderItem" ADD COLUMN "netCents" INTEGER;
+ALTER TABLE "OrderItem" ADD COLUMN "grossCents" INTEGER;
+
+-- OrderItem: Add FK constraint to TaxProfile
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_taxProfileId_fkey" FOREIGN KEY ("taxProfileId") REFERENCES "TaxProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- OrderItem: Add index on taxProfileId
+CREATE INDEX "OrderItem_taxProfileId_idx" ON "OrderItem"("taxProfileId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -334,6 +334,11 @@ model SubOrder {
   subOrderNumber String         @unique
   subTotalCents  Int
 
+  // VAT snapshot totals (N1.2) - captured at order time, nullable for historical orders
+  netTotalCents   Int? // Sum of all line items net amounts
+  vatTotalCents   Int? // Sum of all line items VAT amounts
+  grossTotalCents Int? // Sum of all line items gross amounts
+
   // Payment tracking (Phase 11)
   stripeChargeId String?
   paidAt         DateTime?
@@ -379,24 +384,34 @@ model SubOrder {
 }
 
 model OrderItem {
-  id              String        @id
+  id              String   @id
   orderId         String
   vendorProductId String
   qty             Int
   unitPriceCents  Int
   lineTotalCents  Int
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
   productName     String
   vendorName      String
   subOrderId      String?
-  Order           Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  VendorProduct   VendorProduct @relation(fields: [vendorProductId], references: [id])
-  SubOrder        SubOrder?     @relation(fields: [subOrderId], references: [id], onDelete: Cascade)
+
+  // VAT snapshot fields (N1.2) - captured at order time, nullable for historical orders
+  taxProfileId   String? // FK to TaxProfile at time of order
+  vatRateBps     Int? // VAT rate in basis points (e.g., 2200 = 22%)
+  vatAmountCents Int? // Calculated VAT amount for this line
+  netCents       Int? // Net amount (before VAT)
+  grossCents     Int? // Gross amount (after VAT)
+
+  Order         Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  VendorProduct VendorProduct @relation(fields: [vendorProductId], references: [id])
+  SubOrder      SubOrder?     @relation(fields: [subOrderId], references: [id], onDelete: Cascade)
+  TaxProfile    TaxProfile?   @relation(fields: [taxProfileId], references: [id])
 
   @@index([orderId])
   @@index([vendorProductId])
   @@index([subOrderId])
+  @@index([taxProfileId])
 }
 
 model Product {
@@ -465,6 +480,7 @@ model TaxProfile {
   // Relations
   ProductCategory ProductCategory[]
   Product         Product[]
+  OrderItem       OrderItem[]
 
   @@index([vatRateBps])
 }
@@ -523,6 +539,9 @@ model Vendor {
   stripeAccountId String? @unique // Stripe Connect account ID for receiving payments
   chargesEnabled  Boolean @default(false) // Whether the vendor can accept charges
   payoutsEnabled  Boolean @default(false) // Whether the vendor can receive payouts
+
+  // VAT pricing mode (N1.2)
+  priceIncludesVat Boolean @default(false) // false = NET pricing (add VAT), true = GROSS pricing (VAT included)
 
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt


### PR DESCRIPTION
## Summary
- Add `Vendor.priceIncludesVat` Boolean flag with `@default(false)` for NET pricing mode
- Add VAT totals to `SubOrder`: `netTotalCents`, `vatTotalCents`, `grossTotalCents`
- Add VAT snapshot fields to `OrderItem`: `taxProfileId`, `vatRateBps`, `vatAmountCents`, `netCents`, `grossCents`

## Schema Changes

### Vendor
| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `priceIncludesVat` | Boolean | `false` | `false` = NET pricing (add VAT), `true` = GROSS pricing (VAT included) |

### SubOrder
| Field | Type | Nullable | Description |
|-------|------|----------|-------------|
| `netTotalCents` | Int | ✅ | Sum of all line items net amounts |
| `vatTotalCents` | Int | ✅ | Sum of all line items VAT amounts |
| `grossTotalCents` | Int | ✅ | Sum of all line items gross amounts |

### OrderItem
| Field | Type | Nullable | Description |
|-------|------|----------|-------------|
| `taxProfileId` | String (FK) | ✅ | FK to TaxProfile at time of order |
| `vatRateBps` | Int | ✅ | VAT rate in basis points (e.g., 2200 = 22%) |
| `vatAmountCents` | Int | ✅ | Calculated VAT amount for this line |
| `netCents` | Int | ✅ | Net amount (before VAT) |
| `grossCents` | Int | ✅ | Gross amount (after VAT) |

## Migration Notes
- **Backwards compatible**: All new columns are nullable (except `priceIncludesVat` which has a default)
- **No data loss**: Existing orders remain unaffected with `NULL` values
- **No backfill required**: Historical orders intentionally keep null values per issue spec

## Seed/Backfill Notes
None required - fields stay null for existing orders (intentional per issue scope).

## Test Plan
- [ ] Run `npx prisma migrate deploy` - should apply cleanly
- [ ] Verify existing orders still query correctly with null VAT fields
- [ ] Verify `Vendor.priceIncludesVat` defaults to `false` for existing vendors
- [ ] Verify new OrderItem can be created with VAT snapshot fields populated
- [ ] Verify FK constraint: OrderItem.taxProfileId references valid TaxProfile

Closes #120