### PR TITLE
feat(vat): implement VAT computation + snapshotting for new orders (#121)

### DIFF
--- a/src/data/__tests__/order-vat.test.ts
+++ b/src/data/__tests__/order-vat.test.ts
@@ -1,0 +1,667 @@
+/**
+ * Integration tests for order creation with VAT snapshotting (N1.3)
+ *
+ * Tests the createOrderFromCart function to verify:
+ * - OrderItems have VAT snapshot fields populated
+ * - SubOrder has VAT totals populated
+ * - The invariant net + vat = gross holds
+ * - Both priceIncludesVat=false (NET) and priceIncludesVat=true (GROSS) work correctly
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Deterministic ID counter for test stability
+let idCounter = 0;
+vi.mock("@paralleldrive/cuid2", () => ({
+  createId: vi.fn(() => `test-id-${++idCounter}`),
+}));
+
+import { createOrderFromCart } from "../order";
+
+// Mock dependencies
+vi.mock("@/lib/auth", () => ({
+  currentUser: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    cart: {
+      findFirst: vi.fn(),
+    },
+    order: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    subOrder: {
+      create: vi.fn(),
+    },
+    orderItem: {
+      createMany: vi.fn(),
+    },
+    cartItem: {
+      deleteMany: vi.fn(),
+    },
+    product: {
+      findUnique: vi.fn(),
+    },
+    taxProfile: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/data/cart-recalc", () => ({
+  recalcCartPricesForUser: vi.fn(),
+}));
+
+import { currentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { recalcCartPricesForUser } from "@/data/cart-recalc";
+
+// Common mock user for all tests
+const mockClientUser = {
+  id: "user-123",
+  email: "client@test.com",
+  name: "Test Client",
+  role: "CLIENT" as const,
+  vendorId: null,
+  clientId: "client-123",
+  agentCode: null,
+  driverId: null,
+};
+
+describe("createOrderFromCart with VAT", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idCounter = 0; // Reset counter for each test
+  });
+
+  /**
+   * Test case: NET pricing (priceIncludesVat = false)
+   *
+   * When vendor uses NET pricing:
+   * - lineTotalCents is the NET amount
+   * - VAT is computed on top: gross = net + vat
+   * - OrderItem.netCents = lineTotalCents
+   * - OrderItem.grossCents = lineTotalCents + vatAmountCents
+   */
+  it("should populate VAT fields for NET pricing (priceIncludesVat=false)", async () => {
+    vi.mocked(currentUser).mockResolvedValue(mockClientUser);
+    vi.mocked(recalcCartPricesForUser).mockResolvedValue([]);
+
+    // Mock cart with items - NET pricing vendor, 10% VAT category
+    vi.mocked(prisma.cart.findFirst).mockResolvedValue({
+      id: "cart-123",
+      clientId: "client-123",
+      status: "ACTIVE",
+      CartItem: [
+        {
+          id: "cartitem-1",
+          vendorProductId: "vp-1",
+          qty: 2,
+          unitPriceCents: 1000, // €10.00 net per unit
+          VendorProduct: {
+            Product: {
+              id: "prod-1",
+              name: "Test Product",
+              taxProfileId: null, // Use category tax profile
+              TaxProfile: null,
+              ProductCategory: {
+                taxProfileId: "tp-reduced-10",
+                TaxProfile: {
+                  id: "tp-reduced-10",
+                  vatRateBps: 1000, // 10%
+                },
+              },
+            },
+            Vendor: {
+              id: "vendor-1",
+              name: "Test Vendor",
+              priceIncludesVat: false, // NET pricing
+            },
+          },
+        },
+      ],
+    } as any);
+
+    // Capture what gets created
+    let capturedOrderItems: any[] = [];
+    let capturedSubOrder: any = null;
+
+    // Mock transaction to execute callback
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      // Create mock transaction client
+      const tx = {
+        order: {
+          findFirst: vi.fn().mockResolvedValue(null), // Order number unique
+          create: vi.fn().mockResolvedValue({
+            id: "order-123",
+          }),
+        },
+        subOrder: {
+          create: vi.fn().mockImplementation(({ data }) => {
+            capturedSubOrder = data;
+            return Promise.resolve({ id: data.id, vendorId: data.vendorId });
+          }),
+        },
+        orderItem: {
+          createMany: vi.fn().mockImplementation(({ data }) => {
+            capturedOrderItems = data;
+            return Promise.resolve({ count: data.length });
+          }),
+        },
+        cartItem: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+      };
+
+      return callback(tx);
+    });
+
+    // Execute
+    const result = await createOrderFromCart();
+
+    // Verify result
+    expect(result.orderId).toBeDefined();
+
+    // Verify OrderItem VAT fields
+    // lineTotalCents = 2 * 1000 = 2000 (NET)
+    // vatAmountCents = 2000 * 1000 / 10000 = 200
+    // grossCents = 2000 + 200 = 2200
+    expect(capturedOrderItems).toHaveLength(1);
+    const orderItem = capturedOrderItems[0];
+
+    expect(orderItem.lineTotalCents).toBe(2000);
+    expect(orderItem.taxProfileId).toBe("tp-reduced-10");
+    expect(orderItem.vatRateBps).toBe(1000);
+    expect(orderItem.netCents).toBe(2000);
+    expect(orderItem.vatAmountCents).toBe(200);
+    expect(orderItem.grossCents).toBe(2200);
+
+    // Verify invariant: net + vat = gross
+    expect(orderItem.netCents + orderItem.vatAmountCents).toBe(
+      orderItem.grossCents,
+    );
+
+    // Verify SubOrder VAT totals
+    expect(capturedSubOrder.netTotalCents).toBe(2000);
+    expect(capturedSubOrder.vatTotalCents).toBe(200);
+    expect(capturedSubOrder.grossTotalCents).toBe(2200);
+
+    // Verify SubOrder invariant
+    expect(
+      capturedSubOrder.netTotalCents + capturedSubOrder.vatTotalCents,
+    ).toBe(capturedSubOrder.grossTotalCents);
+  });
+
+  /**
+   * Test case: GROSS pricing (priceIncludesVat = true)
+   *
+   * When vendor uses GROSS pricing:
+   * - lineTotalCents is the GROSS amount (VAT-inclusive)
+   * - VAT is extracted: net = gross - vat
+   * - OrderItem.grossCents = lineTotalCents
+   * - OrderItem.netCents = lineTotalCents - vatAmountCents
+   */
+  it("should populate VAT fields for GROSS pricing (priceIncludesVat=true)", async () => {
+    vi.mocked(currentUser).mockResolvedValue(mockClientUser);
+    vi.mocked(recalcCartPricesForUser).mockResolvedValue([]);
+
+    // Mock cart with items - GROSS pricing vendor, 22% VAT
+    vi.mocked(prisma.cart.findFirst).mockResolvedValue({
+      id: "cart-123",
+      clientId: "client-123",
+      status: "ACTIVE",
+      CartItem: [
+        {
+          id: "cartitem-1",
+          vendorProductId: "vp-1",
+          qty: 1,
+          unitPriceCents: 1220, // €12.20 gross per unit (includes 22% VAT)
+          VendorProduct: {
+            Product: {
+              id: "prod-1",
+              name: "Test Product",
+              taxProfileId: "tp-standard-22", // Product-level override
+              TaxProfile: {
+                id: "tp-standard-22",
+                vatRateBps: 2200, // 22%
+              },
+              ProductCategory: {
+                taxProfileId: "tp-reduced-10",
+                TaxProfile: {
+                  id: "tp-reduced-10",
+                  vatRateBps: 1000,
+                },
+              },
+            },
+            Vendor: {
+              id: "vendor-2",
+              name: "Gross Vendor",
+              priceIncludesVat: true, // GROSS pricing
+            },
+          },
+        },
+      ],
+    } as any);
+
+    // Capture what gets created
+    let capturedOrderItems: any[] = [];
+    let capturedSubOrder: any = null;
+
+    // Mock transaction
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        order: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "order-456" }),
+        },
+        subOrder: {
+          create: vi.fn().mockImplementation(({ data }) => {
+            capturedSubOrder = data;
+            return Promise.resolve({ id: data.id, vendorId: data.vendorId });
+          }),
+        },
+        orderItem: {
+          createMany: vi.fn().mockImplementation(({ data }) => {
+            capturedOrderItems = data;
+            return Promise.resolve({ count: data.length });
+          }),
+        },
+        cartItem: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+      };
+
+      return callback(tx);
+    });
+
+    // Execute
+    const result = await createOrderFromCart();
+
+    // Verify result
+    expect(result.orderId).toBeDefined();
+
+    // Verify OrderItem VAT fields
+    // lineTotalCents = 1 * 1220 = 1220 (GROSS)
+    // netCents = 1220 * 10000 / 12200 = 1000
+    // vatAmountCents = 1220 - 1000 = 220
+    expect(capturedOrderItems).toHaveLength(1);
+    const orderItem = capturedOrderItems[0];
+
+    expect(orderItem.lineTotalCents).toBe(1220);
+    expect(orderItem.taxProfileId).toBe("tp-standard-22");
+    expect(orderItem.vatRateBps).toBe(2200);
+    expect(orderItem.netCents).toBe(1000);
+    expect(orderItem.vatAmountCents).toBe(220);
+    expect(orderItem.grossCents).toBe(1220);
+
+    // Verify invariant: net + vat = gross
+    expect(orderItem.netCents + orderItem.vatAmountCents).toBe(
+      orderItem.grossCents,
+    );
+
+    // Verify SubOrder VAT totals
+    expect(capturedSubOrder.netTotalCents).toBe(1000);
+    expect(capturedSubOrder.vatTotalCents).toBe(220);
+    expect(capturedSubOrder.grossTotalCents).toBe(1220);
+
+    // Verify SubOrder invariant
+    expect(
+      capturedSubOrder.netTotalCents + capturedSubOrder.vatTotalCents,
+    ).toBe(capturedSubOrder.grossTotalCents);
+  });
+
+  /**
+   * Test case: Multiple items with different VAT rates
+   *
+   * Verifies that:
+   * - Each item gets the correct VAT computation
+   * - SubOrder totals are correct sums
+   * - Invariant holds for mixed rates
+   */
+  it("should handle multiple items with different VAT rates", async () => {
+    vi.mocked(currentUser).mockResolvedValue(mockClientUser);
+    vi.mocked(recalcCartPricesForUser).mockResolvedValue([]);
+
+    // Mock cart with multiple items - NET pricing
+    vi.mocked(prisma.cart.findFirst).mockResolvedValue({
+      id: "cart-123",
+      clientId: "client-123",
+      status: "ACTIVE",
+      CartItem: [
+        {
+          id: "cartitem-1",
+          vendorProductId: "vp-1",
+          qty: 1,
+          unitPriceCents: 1000, // €10.00 net
+          VendorProduct: {
+            Product: {
+              id: "prod-1",
+              name: "Standard Product",
+              taxProfileId: "tp-standard-22",
+              TaxProfile: {
+                id: "tp-standard-22",
+                vatRateBps: 2200, // 22%
+              },
+              ProductCategory: null,
+            },
+            Vendor: {
+              id: "vendor-1",
+              name: "Test Vendor",
+              priceIncludesVat: false,
+            },
+          },
+        },
+        {
+          id: "cartitem-2",
+          vendorProductId: "vp-2",
+          qty: 2,
+          unitPriceCents: 500, // €5.00 net per unit
+          VendorProduct: {
+            Product: {
+              id: "prod-2",
+              name: "Reduced Product",
+              taxProfileId: null,
+              TaxProfile: null,
+              ProductCategory: {
+                taxProfileId: "tp-reduced-10",
+                TaxProfile: {
+                  id: "tp-reduced-10",
+                  vatRateBps: 1000, // 10%
+                },
+              },
+            },
+            Vendor: {
+              id: "vendor-1",
+              name: "Test Vendor",
+              priceIncludesVat: false,
+            },
+          },
+        },
+      ],
+    } as any);
+
+    let capturedOrderItems: any[] = [];
+    let capturedSubOrder: any = null;
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        order: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "order-789" }),
+        },
+        subOrder: {
+          create: vi.fn().mockImplementation(({ data }) => {
+            capturedSubOrder = data;
+            return Promise.resolve({ id: data.id, vendorId: data.vendorId });
+          }),
+        },
+        orderItem: {
+          createMany: vi.fn().mockImplementation(({ data }) => {
+            capturedOrderItems = data;
+            return Promise.resolve({ count: data.length });
+          }),
+        },
+        cartItem: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 2 }),
+        },
+      };
+
+      return callback(tx);
+    });
+
+    // Execute
+    await createOrderFromCart();
+
+    // Verify both items
+    expect(capturedOrderItems).toHaveLength(2);
+
+    // Item 1: 1000 net at 22% -> 220 VAT -> 1220 gross
+    const item1 = capturedOrderItems.find((i) => i.vendorProductId === "vp-1");
+    expect(item1).toBeDefined();
+    expect(item1!.netCents).toBe(1000);
+    expect(item1!.vatAmountCents).toBe(220);
+    expect(item1!.grossCents).toBe(1220);
+    expect(item1!.netCents + item1!.vatAmountCents).toBe(item1!.grossCents);
+
+    // Item 2: 2*500=1000 net at 10% -> 100 VAT -> 1100 gross
+    const item2 = capturedOrderItems.find((i) => i.vendorProductId === "vp-2");
+    expect(item2).toBeDefined();
+    expect(item2!.netCents).toBe(1000);
+    expect(item2!.vatAmountCents).toBe(100);
+    expect(item2!.grossCents).toBe(1100);
+    expect(item2!.netCents + item2!.vatAmountCents).toBe(item2!.grossCents);
+
+    // Verify SubOrder totals (sum of items)
+    // netTotal = 1000 + 1000 = 2000
+    // vatTotal = 220 + 100 = 320
+    // grossTotal = 1220 + 1100 = 2320
+    expect(capturedSubOrder.netTotalCents).toBe(2000);
+    expect(capturedSubOrder.vatTotalCents).toBe(320);
+    expect(capturedSubOrder.grossTotalCents).toBe(2320);
+
+    // Verify SubOrder invariant
+    expect(
+      capturedSubOrder.netTotalCents + capturedSubOrder.vatTotalCents,
+    ).toBe(capturedSubOrder.grossTotalCents);
+  });
+
+  /**
+   * Test case: 0% VAT (exempt)
+   *
+   * Verifies that exempt products (0% VAT) work correctly:
+   * - vatAmountCents = 0
+   * - netCents = grossCents
+   */
+  it("should handle 0% VAT (exempt) correctly", async () => {
+    vi.mocked(currentUser).mockResolvedValue(mockClientUser);
+    vi.mocked(recalcCartPricesForUser).mockResolvedValue([]);
+
+    vi.mocked(prisma.cart.findFirst).mockResolvedValue({
+      id: "cart-123",
+      clientId: "client-123",
+      status: "ACTIVE",
+      CartItem: [
+        {
+          id: "cartitem-1",
+          vendorProductId: "vp-1",
+          qty: 1,
+          unitPriceCents: 1000,
+          VendorProduct: {
+            Product: {
+              id: "prod-1",
+              name: "Exempt Product",
+              taxProfileId: "tp-exempt-0",
+              TaxProfile: {
+                id: "tp-exempt-0",
+                vatRateBps: 0, // 0% exempt
+              },
+              ProductCategory: null,
+            },
+            Vendor: {
+              id: "vendor-1",
+              name: "Test Vendor",
+              priceIncludesVat: false,
+            },
+          },
+        },
+      ],
+    } as any);
+
+    let capturedOrderItems: any[] = [];
+    let capturedSubOrder: any = null;
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        order: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "order-exempt" }),
+        },
+        subOrder: {
+          create: vi.fn().mockImplementation(({ data }) => {
+            capturedSubOrder = data;
+            return Promise.resolve({ id: data.id, vendorId: data.vendorId });
+          }),
+        },
+        orderItem: {
+          createMany: vi.fn().mockImplementation(({ data }) => {
+            capturedOrderItems = data;
+            return Promise.resolve({ count: data.length });
+          }),
+        },
+        cartItem: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+      };
+
+      return callback(tx);
+    });
+
+    await createOrderFromCart();
+
+    const orderItem = capturedOrderItems[0];
+
+    // 0% VAT: net = gross, vat = 0
+    expect(orderItem.vatRateBps).toBe(0);
+    expect(orderItem.vatAmountCents).toBe(0);
+    expect(orderItem.netCents).toBe(1000);
+    expect(orderItem.grossCents).toBe(1000);
+
+    // Invariant still holds
+    expect(orderItem.netCents + orderItem.vatAmountCents).toBe(
+      orderItem.grossCents,
+    );
+
+    // SubOrder totals
+    expect(capturedSubOrder.netTotalCents).toBe(1000);
+    expect(capturedSubOrder.vatTotalCents).toBe(0);
+    expect(capturedSubOrder.grossTotalCents).toBe(1000);
+  });
+
+  /**
+   * Test case: Multiple vendors (multiple SubOrders)
+   *
+   * Verifies that each vendor gets its own SubOrder with correct VAT totals
+   */
+  it("should create separate SubOrders for different vendors with correct VAT", async () => {
+    vi.mocked(currentUser).mockResolvedValue(mockClientUser);
+    vi.mocked(recalcCartPricesForUser).mockResolvedValue([]);
+
+    // Two items from different vendors
+    vi.mocked(prisma.cart.findFirst).mockResolvedValue({
+      id: "cart-123",
+      clientId: "client-123",
+      status: "ACTIVE",
+      CartItem: [
+        {
+          id: "cartitem-1",
+          vendorProductId: "vp-1",
+          qty: 1,
+          unitPriceCents: 1000,
+          VendorProduct: {
+            Product: {
+              id: "prod-1",
+              name: "Product A",
+              taxProfileId: null,
+              TaxProfile: null,
+              ProductCategory: {
+                taxProfileId: "tp-reduced-10",
+                TaxProfile: {
+                  id: "tp-reduced-10",
+                  vatRateBps: 1000,
+                },
+              },
+            },
+            Vendor: {
+              id: "vendor-1",
+              name: "Vendor One",
+              priceIncludesVat: false,
+            },
+          },
+        },
+        {
+          id: "cartitem-2",
+          vendorProductId: "vp-2",
+          qty: 1,
+          unitPriceCents: 1220,
+          VendorProduct: {
+            Product: {
+              id: "prod-2",
+              name: "Product B",
+              taxProfileId: "tp-standard-22",
+              TaxProfile: {
+                id: "tp-standard-22",
+                vatRateBps: 2200,
+              },
+              ProductCategory: null,
+            },
+            Vendor: {
+              id: "vendor-2",
+              name: "Vendor Two",
+              priceIncludesVat: true, // Different pricing mode
+            },
+          },
+        },
+      ],
+    } as any);
+
+    const capturedSubOrders: any[] = [];
+    let capturedOrderItems: any[] = [];
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        order: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "order-multi" }),
+        },
+        subOrder: {
+          create: vi.fn().mockImplementation(({ data }) => {
+            capturedSubOrders.push(data);
+            return Promise.resolve({ id: data.id, vendorId: data.vendorId });
+          }),
+        },
+        orderItem: {
+          createMany: vi.fn().mockImplementation(({ data }) => {
+            capturedOrderItems = data;
+            return Promise.resolve({ count: data.length });
+          }),
+        },
+        cartItem: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 2 }),
+        },
+      };
+
+      return callback(tx);
+    });
+
+    await createOrderFromCart();
+
+    // Should create 2 SubOrders
+    expect(capturedSubOrders).toHaveLength(2);
+
+    // Vendor 1 (NET): 1000 net + 100 vat = 1100 gross
+    const subOrder1 = capturedSubOrders.find((s) => s.vendorId === "vendor-1");
+    expect(subOrder1).toBeDefined();
+    expect(subOrder1!.netTotalCents).toBe(1000);
+    expect(subOrder1!.vatTotalCents).toBe(100);
+    expect(subOrder1!.grossTotalCents).toBe(1100);
+
+    // Vendor 2 (GROSS): 1220 gross = 1000 net + 220 vat
+    const subOrder2 = capturedSubOrders.find((s) => s.vendorId === "vendor-2");
+    expect(subOrder2).toBeDefined();
+    expect(subOrder2!.netTotalCents).toBe(1000);
+    expect(subOrder2!.vatTotalCents).toBe(220);
+    expect(subOrder2!.grossTotalCents).toBe(1220);
+
+    // Both invariants hold
+    expect(subOrder1!.netTotalCents + subOrder1!.vatTotalCents).toBe(
+      subOrder1!.grossTotalCents,
+    );
+    expect(subOrder2!.netTotalCents + subOrder2!.vatTotalCents).toBe(
+      subOrder2!.grossTotalCents,
+    );
+  });
+});

--- a/src/lib/__tests__/vat.test.ts
+++ b/src/lib/__tests__/vat.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  computeVatFromGross,
+  computeVatFromNet,
+  getEffectiveTaxProfile,
+} from "../vat";
+import { prisma } from "../prisma";
+
+// Mock prisma
+vi.mock("../prisma", () => ({
+  prisma: {
+    product: {
+      findUnique: vi.fn(),
+    },
+    taxProfile: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("VAT computation helpers", () => {
+  describe("computeVatFromGross", () => {
+    it("should compute 10% VAT from gross=1000 -> net=909, vat=91", () => {
+      const result = computeVatFromGross(1000, 1000); // 10% = 1000 bps
+      expect(result).toEqual({
+        netCents: 909,
+        vatCents: 91,
+        grossCents: 1000,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should compute 22% VAT from gross=1220 -> net=1000, vat=220", () => {
+      const result = computeVatFromGross(1220, 2200); // 22% = 2200 bps
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 220,
+        grossCents: 1220,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should compute 22% VAT from gross=100 -> net=82, vat=18", () => {
+      const result = computeVatFromGross(100, 2200); // 22% = 2200 bps
+      // 100 * 10000 / 12200 = 81.967... -> rounds to 82
+      expect(result).toEqual({
+        netCents: 82,
+        vatCents: 18,
+        grossCents: 100,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should compute 4% VAT from gross=1040 -> net=1000, vat=40", () => {
+      const result = computeVatFromGross(1040, 400); // 4% = 400 bps
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 40,
+        grossCents: 1040,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should handle 0% VAT (exempt) -> vat=0, net=gross", () => {
+      const result = computeVatFromGross(1000, 0);
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 0,
+        grossCents: 1000,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should handle zero gross amount", () => {
+      const result = computeVatFromGross(0, 2200);
+      expect(result).toEqual({
+        netCents: 0,
+        vatCents: 0,
+        grossCents: 0,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should throw error for negative gross amount", () => {
+      expect(() => computeVatFromGross(-100, 2200)).toThrow(
+        "grossCents cannot be negative",
+      );
+    });
+
+    it("should throw error for negative VAT rate", () => {
+      expect(() => computeVatFromGross(1000, -100)).toThrow(
+        "vatRateBps cannot be negative",
+      );
+    });
+
+    it("should maintain invariant: net + vat = gross for various amounts", () => {
+      const testCases = [
+        { gross: 1, rate: 2200 },
+        { gross: 99, rate: 2200 },
+        { gross: 123, rate: 1000 },
+        { gross: 9999, rate: 2200 },
+        { gross: 10000, rate: 400 },
+        { gross: 100000, rate: 2200 },
+      ];
+
+      for (const { gross, rate } of testCases) {
+        const result = computeVatFromGross(gross, rate);
+        expect(result.netCents + result.vatCents).toBe(result.grossCents);
+      }
+    });
+  });
+
+  describe("computeVatFromNet", () => {
+    it("should compute 10% VAT from net=1000 -> vat=100, gross=1100", () => {
+      const result = computeVatFromNet(1000, 1000); // 10% = 1000 bps
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 100,
+        grossCents: 1100,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should compute 22% VAT from net=1000 -> vat=220, gross=1220", () => {
+      const result = computeVatFromNet(1000, 2200); // 22% = 2200 bps
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 220,
+        grossCents: 1220,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should compute 4% VAT from net=1000 -> vat=40, gross=1040", () => {
+      const result = computeVatFromNet(1000, 400); // 4% = 400 bps
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 40,
+        grossCents: 1040,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should handle 0% VAT (exempt) -> vat=0, gross=net", () => {
+      const result = computeVatFromNet(1000, 0);
+      expect(result).toEqual({
+        netCents: 1000,
+        vatCents: 0,
+        grossCents: 1000,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should handle zero net amount", () => {
+      const result = computeVatFromNet(0, 2200);
+      expect(result).toEqual({
+        netCents: 0,
+        vatCents: 0,
+        grossCents: 0,
+      });
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should throw error for negative net amount", () => {
+      expect(() => computeVatFromNet(-100, 2200)).toThrow(
+        "netCents cannot be negative",
+      );
+    });
+
+    it("should throw error for negative VAT rate", () => {
+      expect(() => computeVatFromNet(1000, -100)).toThrow(
+        "vatRateBps cannot be negative",
+      );
+    });
+
+    it("should round VAT correctly for odd amounts", () => {
+      // 99 * 2200 / 10000 = 21.78 -> rounds to 22
+      const result = computeVatFromNet(99, 2200);
+      expect(result.vatCents).toBe(22);
+      expect(result.grossCents).toBe(121);
+      // Invariant check
+      expect(result.netCents + result.vatCents).toBe(result.grossCents);
+    });
+
+    it("should maintain invariant: net + vat = gross for various amounts", () => {
+      const testCases = [
+        { net: 1, rate: 2200 },
+        { net: 99, rate: 2200 },
+        { net: 123, rate: 1000 },
+        { net: 9999, rate: 2200 },
+        { net: 10000, rate: 400 },
+        { net: 100000, rate: 2200 },
+      ];
+
+      for (const { net, rate } of testCases) {
+        const result = computeVatFromNet(net, rate);
+        expect(result.netCents + result.vatCents).toBe(result.grossCents);
+      }
+    });
+  });
+
+  describe("getEffectiveTaxProfile", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should return product-level tax profile when set", async () => {
+      const result = await getEffectiveTaxProfile({
+        product: {
+          taxProfileId: "tp-product",
+          TaxProfile: { id: "tp-product", vatRateBps: 2200 },
+          ProductCategory: {
+            taxProfileId: "tp-category",
+            TaxProfile: { id: "tp-category", vatRateBps: 1000 },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        taxProfileId: "tp-product",
+        vatRateBps: 2200,
+      });
+    });
+
+    it("should return category-level tax profile when product has none", async () => {
+      const result = await getEffectiveTaxProfile({
+        product: {
+          taxProfileId: null,
+          TaxProfile: null,
+          ProductCategory: {
+            taxProfileId: "tp-category",
+            TaxProfile: { id: "tp-category", vatRateBps: 1000 },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        taxProfileId: "tp-category",
+        vatRateBps: 1000,
+      });
+    });
+
+    it("should fetch from DB when productId is provided", async () => {
+      vi.mocked(prisma.product.findUnique).mockResolvedValue({
+        taxProfileId: "tp-product",
+        TaxProfile: { id: "tp-product", vatRateBps: 2200 },
+        ProductCategory: {
+          taxProfileId: "tp-category",
+          TaxProfile: { id: "tp-category", vatRateBps: 1000 },
+        },
+      } as any);
+
+      const result = await getEffectiveTaxProfile({
+        productId: "prod-123",
+      });
+
+      expect(prisma.product.findUnique).toHaveBeenCalledWith({
+        where: { id: "prod-123" },
+        select: {
+          taxProfileId: true,
+          TaxProfile: {
+            select: { id: true, vatRateBps: true },
+          },
+          ProductCategory: {
+            select: {
+              taxProfileId: true,
+              TaxProfile: {
+                select: { id: true, vatRateBps: true },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        taxProfileId: "tp-product",
+        vatRateBps: 2200,
+      });
+    });
+
+    it("should return global fallback when product and category have no profile", async () => {
+      vi.mocked(prisma.product.findUnique).mockResolvedValue({
+        taxProfileId: null,
+        TaxProfile: null,
+        ProductCategory: {
+          taxProfileId: null,
+          TaxProfile: null,
+        },
+      } as any);
+
+      // Combined query returns isDefault profile
+      vi.mocked(prisma.taxProfile.findFirst).mockResolvedValue({
+        id: "tp-default",
+        vatRateBps: 2200,
+      } as any);
+
+      const result = await getEffectiveTaxProfile({
+        productId: "prod-123",
+      });
+
+      // Verify combined fallback query
+      expect(prisma.taxProfile.findFirst).toHaveBeenCalledWith({
+        where: {
+          OR: [{ isDefault: true }, { name: "reduced_10" }],
+        },
+        orderBy: {
+          isDefault: "desc",
+        },
+        select: { id: true, vatRateBps: true },
+      });
+
+      expect(result).toEqual({
+        taxProfileId: "tp-default",
+        vatRateBps: 2200,
+      });
+    });
+
+    it("should throw error when no profiles exist (fail fast)", async () => {
+      vi.mocked(prisma.product.findUnique).mockResolvedValue({
+        taxProfileId: null,
+        TaxProfile: null,
+        ProductCategory: {
+          taxProfileId: null,
+          TaxProfile: null,
+        },
+      } as any);
+
+      vi.mocked(prisma.taxProfile.findFirst).mockResolvedValue(null);
+
+      await expect(
+        getEffectiveTaxProfile({ productId: "prod-123" }),
+      ).rejects.toThrow("No TaxProfile found for product");
+    });
+
+    it("should use fallback when product not found in DB", async () => {
+      vi.mocked(prisma.product.findUnique).mockResolvedValue(null);
+
+      vi.mocked(prisma.taxProfile.findFirst).mockResolvedValue({
+        id: "tp-fallback",
+        vatRateBps: 1000,
+      } as any);
+
+      const result = await getEffectiveTaxProfile({
+        productId: "non-existent-product",
+      });
+
+      expect(result).toEqual({
+        taxProfileId: "tp-fallback",
+        vatRateBps: 1000,
+      });
+    });
+  });
+});

--- a/src/lib/vat.ts
+++ b/src/lib/vat.ts
@@ -1,0 +1,241 @@
+/**
+ * VAT Computation Helpers (N1.3)
+ *
+ * All amounts are in cents (integers). VAT rates use basis points (bps):
+ * - 2200 bps = 22.00%
+ * - 1000 bps = 10.00%
+ * - 400 bps = 4.00%
+ * - 0 bps = 0.00% (exempt)
+ *
+ * NO FLOATS for tax math. All calculations use integers with rounding.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+/** Result of VAT computation with net, VAT, and gross amounts in cents */
+export interface VatComputationResult {
+  netCents: number;
+  vatCents: number;
+  grossCents: number;
+}
+
+/**
+ * Compute VAT breakdown from a GROSS amount (VAT-inclusive pricing).
+ *
+ * Formula: net = gross * 10000 / (10000 + vatRateBps)
+ *          vat = gross - net
+ *
+ * @param grossCents - Total amount including VAT (in cents)
+ * @param vatRateBps - VAT rate in basis points (e.g., 2200 for 22%)
+ * @returns Object with netCents, vatCents, grossCents
+ * @throws Error if grossCents < 0 or vatRateBps < 0
+ */
+export function computeVatFromGross(
+  grossCents: number,
+  vatRateBps: number,
+): VatComputationResult {
+  if (grossCents < 0) {
+    throw new Error("grossCents cannot be negative");
+  }
+  if (vatRateBps < 0) {
+    throw new Error("vatRateBps cannot be negative");
+  }
+
+  // Handle 0% VAT (exempt)
+  if (vatRateBps === 0) {
+    return {
+      netCents: grossCents,
+      vatCents: 0,
+      grossCents: grossCents,
+    };
+  }
+
+  // net = gross * 10000 / (10000 + vatRateBps)
+  // Using integer math with rounding
+  const netCents = Math.round((grossCents * 10000) / (10000 + vatRateBps));
+  const vatCents = grossCents - netCents;
+
+  // Defensive check: invariant should always hold by construction (vat = gross - net),
+  // but we verify in case the formula or rounding logic is modified in future refactoring.
+  if (netCents + vatCents !== grossCents) {
+    throw new Error(
+      `VAT invariant violated: ${netCents} + ${vatCents} !== ${grossCents}`,
+    );
+  }
+
+  return {
+    netCents,
+    vatCents,
+    grossCents,
+  };
+}
+
+/**
+ * Compute VAT breakdown from a NET amount (VAT-exclusive pricing).
+ *
+ * Formula: vat = net * vatRateBps / 10000
+ *          gross = net + vat
+ *
+ * @param netCents - Amount before VAT (in cents)
+ * @param vatRateBps - VAT rate in basis points (e.g., 2200 for 22%)
+ * @returns Object with netCents, vatCents, grossCents
+ * @throws Error if netCents < 0 or vatRateBps < 0
+ */
+export function computeVatFromNet(
+  netCents: number,
+  vatRateBps: number,
+): VatComputationResult {
+  if (netCents < 0) {
+    throw new Error("netCents cannot be negative");
+  }
+  if (vatRateBps < 0) {
+    throw new Error("vatRateBps cannot be negative");
+  }
+
+  // Handle 0% VAT (exempt)
+  if (vatRateBps === 0) {
+    return {
+      netCents: netCents,
+      vatCents: 0,
+      grossCents: netCents,
+    };
+  }
+
+  // vat = net * vatRateBps / 10000
+  const vatCents = Math.round((netCents * vatRateBps) / 10000);
+  const grossCents = netCents + vatCents;
+
+  // Invariant always holds by construction (gross = net + vat)
+  return {
+    netCents,
+    vatCents,
+    grossCents,
+  };
+}
+
+/** Tax profile result from resolution */
+export interface EffectiveTaxProfile {
+  taxProfileId: string;
+  vatRateBps: number;
+}
+
+/** Product shape for tax profile extraction */
+interface ProductWithTaxRelations {
+  taxProfileId: string | null;
+  TaxProfile?: { id: string; vatRateBps: number } | null;
+  ProductCategory?: {
+    taxProfileId: string | null;
+    TaxProfile?: { id: string; vatRateBps: number } | null;
+  } | null;
+}
+
+/**
+ * Extract tax profile from a product object (handles both product-level and category-level).
+ * Returns null if no tax profile is found at either level.
+ */
+function extractTaxProfileFromProduct(
+  product: ProductWithTaxRelations,
+): EffectiveTaxProfile | null {
+  // 1. Product-level override
+  if (product.taxProfileId && product.TaxProfile) {
+    return {
+      taxProfileId: product.TaxProfile.id,
+      vatRateBps: product.TaxProfile.vatRateBps,
+    };
+  }
+
+  // 2. Category-level tax profile
+  if (
+    product.ProductCategory?.taxProfileId &&
+    product.ProductCategory.TaxProfile
+  ) {
+    return {
+      taxProfileId: product.ProductCategory.TaxProfile.id,
+      vatRateBps: product.ProductCategory.TaxProfile.vatRateBps,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the effective TaxProfile for a product.
+ *
+ * Resolution order:
+ * 1. Product.taxProfileId (explicit override)
+ * 2. ProductCategory.taxProfileId (inherited from category)
+ * 3. TaxProfile with isDefault=true or named "reduced_10" (global fallback)
+ * 4. Throws error if no profile found (fail fast to prevent invalid FK references)
+ *
+ * @param params - Either { productId: string } or { product: { taxProfileId, category, ... } }
+ * @returns EffectiveTaxProfile with taxProfileId and vatRateBps
+ * @throws Error if no TaxProfile can be resolved
+ */
+export async function getEffectiveTaxProfile(params: {
+  productId?: string;
+  product?: ProductWithTaxRelations;
+}): Promise<EffectiveTaxProfile> {
+  const { productId, product } = params;
+
+  // If product object is provided with relations, try to extract directly
+  if (product) {
+    const extracted = extractTaxProfileFromProduct(product);
+    if (extracted) {
+      return extracted;
+    }
+  }
+
+  // If productId provided, or product object lacks relations, fetch from DB
+  if (productId) {
+    const dbProduct = await prisma.product.findUnique({
+      where: { id: productId },
+      select: {
+        taxProfileId: true,
+        TaxProfile: {
+          select: { id: true, vatRateBps: true },
+        },
+        ProductCategory: {
+          select: {
+            taxProfileId: true,
+            TaxProfile: {
+              select: { id: true, vatRateBps: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (dbProduct) {
+      const extracted = extractTaxProfileFromProduct(dbProduct);
+      if (extracted) {
+        return extracted;
+      }
+    }
+  }
+
+  // 3. Global fallback: isDefault=true OR named "reduced_10", preferring isDefault
+  const fallbackProfile = await prisma.taxProfile.findFirst({
+    where: {
+      OR: [{ isDefault: true }, { name: "reduced_10" }],
+    },
+    orderBy: {
+      isDefault: "desc", // Prioritize isDefault=true
+    },
+    select: { id: true, vatRateBps: true },
+  });
+
+  if (fallbackProfile) {
+    return {
+      taxProfileId: fallbackProfile.id,
+      vatRateBps: fallbackProfile.vatRateBps,
+    };
+  }
+
+  // 4. Fail fast: No valid TaxProfile found
+  // This should never happen in production if TaxProfile records are properly seeded.
+  // Throwing ensures we don't create OrderItems with invalid taxProfileId FK references.
+  throw new Error(
+    "No TaxProfile found for product. Ensure TaxProfile records are seeded " +
+      "(run db:seed) and products/categories have tax profiles assigned.",
+  );
+}


### PR DESCRIPTION
## Summary

Implements N1.3: VAT computation and snapshotting for new orders only.

- **New `src/lib/vat.ts`**: VAT computation helpers
  - `computeVatFromGross()`: Extract VAT from gross amounts (VAT-inclusive pricing)
  - `computeVatFromNet()`: Compute VAT on net amounts (VAT-exclusive pricing)
  - `getEffectiveTaxProfile()`: Resolve tax profile with priority: Product → Category → Default
  - Throws error if no TaxProfile found (fail fast to prevent invalid FK references)

- **Updated `src/data/order.ts`**: Modified `createOrderFromCart()` to populate VAT fields
  - Reads `Vendor.priceIncludesVat` to determine pricing mode
  - Computes VAT for each OrderItem using resolved TaxProfile
  - Aggregates totals for SubOrder: `netTotalCents`, `vatTotalCents`, `grossTotalCents`
  - Enforces invariant: `net + vat = gross` (throws on violation)

### VAT Handling by Pricing Mode

| Vendor Setting | `lineTotalCents` is | Result |
|----------------|---------------------|--------|
| `priceIncludesVat=false` | NET | `grossCents = lineTotalCents + vatAmountCents` |
| `priceIncludesVat=true` | GROSS | `grossCents = lineTotalCents`, `netCents = lineTotalCents - vatAmountCents` |

### Fields Populated (New Orders Only)

**OrderItem**: `taxProfileId`, `vatRateBps`, `vatAmountCents`, `netCents`, `grossCents`
**SubOrder**: `netTotalCents`, `vatTotalCents`, `grossTotalCents`

Historical orders remain unchanged with nullable VAT fields.

## Test plan

- [x] 24 unit tests for VAT computation helpers (`src/lib/__tests__/vat.test.ts`)
- [x] 5 integration tests for order creation (`src/data/__tests__/order-vat.test.ts`)
  - NET pricing (priceIncludesVat=false)
  - GROSS pricing (priceIncludesVat=true)
  - Multiple items with different VAT rates
  - 0% VAT (exempt)
  - Multiple vendors (separate SubOrders)
- [x] All 29 tests passing