### PR TITLE
N3.1: Secure Demo Mode Isolation

### DIFF
--- a/src/app/demo-signin/demo-signin-form.tsx
+++ b/src/app/demo-signin/demo-signin-form.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { DemoUserCard } from "@/components/auth/demo-user-card";
+import { DEMO_USERS } from "@/lib/demo-mode";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Demo Signin Form (Client Component)
+ * Handles the actual demo signin UI and logic
+ */
+export function DemoSigninForm() {
+  const router = useRouter();
+  const [loadingEmail, setLoadingEmail] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDemoSignin = async (email: string) => {
+    try {
+      setLoadingEmail(email);
+      setError(null);
+
+      // Show spinner for at least 500ms so users see feedback
+      await Promise.all([
+        signIn("demo", {
+          email,
+          redirect: false,
+        }).then((result) => {
+          if (result?.error) {
+            setError("Failed to sign in. Please try again.");
+            console.error("Demo signin error:", result.error);
+          } else if (result?.ok) {
+            // Redirect to dashboard
+            router.push("/dashboard");
+            router.refresh();
+          } else {
+            setError("Unexpected sign-in response. Please try again.");
+            console.error("Unexpected signin result:", result);
+          }
+        }),
+        new Promise((resolve) => setTimeout(resolve, 500)),
+      ]);
+    } catch (err) {
+      setError("An unexpected error occurred");
+      console.error("Demo signin error:", err);
+    } finally {
+      setLoadingEmail(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-6xl">
+        <div className="text-center mb-8">
+          <div className="flex items-center justify-center mb-6">
+            <Image
+              src="/hydra-logo-multiservice.png"
+              alt="Hydra Multi Service"
+              width={400}
+              height={120}
+              className="h-auto w-full max-w-md"
+              priority
+            />
+          </div>
+          <h2 className="text-2xl font-semibold mb-2">Demo Mode</h2>
+          <p className="text-muted-foreground max-w-2xl mx-auto">
+            Select a user below to sign in instantly. Perfect for testing and
+            demonstrations.
+          </p>
+        </div>
+
+        {/* Warning Banner */}
+        <Alert className="mb-6 max-w-2xl mx-auto border-amber-500/50 bg-amber-500/10">
+          <AlertTriangle className="h-4 w-4 text-amber-500" />
+          <AlertDescription className="text-amber-900 dark:text-amber-200">
+            Demo Mode is enabled. This should only be used in development or
+            demo environments. Disable ENABLE_DEMO_MODE in production.
+          </AlertDescription>
+        </Alert>
+
+        {error && (
+          <Alert variant="destructive" className="mb-6 max-w-2xl mx-auto">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Demo User Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+          {DEMO_USERS.map((user) => (
+            <DemoUserCard
+              key={user.email}
+              user={user}
+              onClick={() => handleDemoSignin(user.email)}
+              isLoading={loadingEmail === user.email}
+            />
+          ))}
+        </div>
+
+        {/* Alternative Signin Option */}
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground mb-2">
+            Need to use a different account?
+          </p>
+          <Button variant="outline" asChild>
+            <Link href="/signin">Sign in with Email</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/demo-signin/page.tsx
+++ b/src/app/demo-signin/page.tsx
@@ -1,118 +1,22 @@
-"use client";
-
-import { useState } from "react";
-import { signIn } from "next-auth/react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { DemoUserCard } from "@/components/auth/demo-user-card";
-import { DEMO_USERS } from "@/lib/demo-mode";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertTriangle } from "lucide-react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { redirect } from "next/navigation";
+import { isDemoModeEnabled } from "@/lib/demo-mode";
+import { DemoSigninForm } from "./demo-signin-form";
 
 /**
- * Demo Signin Page
- * Allows one-click signin as any demo user for testing/demos
- * Only accessible when ENABLE_DEMO_MODE=true
+ * Demo Signin Page (Server Component)
+ *
+ * Security: Redirects to /signin if demo mode is disabled.
+ * This prevents the demo signin UI from being shown in production
+ * even if someone navigates directly to /demo-signin.
+ *
+ * In production, isDemoModeEnabled() always returns false regardless
+ * of environment variables, so this page will always redirect.
  */
 export default function DemoSigninPage() {
-  const router = useRouter();
-  const [loadingEmail, setLoadingEmail] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // Redirect to regular signin if demo mode is disabled
+  if (!isDemoModeEnabled()) {
+    redirect("/signin");
+  }
 
-  const handleDemoSignin = async (email: string) => {
-    try {
-      setLoadingEmail(email);
-      setError(null);
-
-      // Show spinner for at least 500ms so users see feedback
-      await Promise.all([
-        signIn("demo", {
-          email,
-          redirect: false,
-        }).then((result) => {
-          if (result?.error) {
-            setError("Failed to sign in. Please try again.");
-            console.error("Demo signin error:", result.error);
-          } else if (result?.ok) {
-            // Redirect to dashboard
-            router.push("/dashboard");
-            router.refresh();
-          } else {
-            setError("Unexpected sign-in response. Please try again.");
-            console.error("Unexpected signin result:", result);
-          }
-        }),
-        new Promise((resolve) => setTimeout(resolve, 500)),
-      ]);
-    } catch (err) {
-      setError("An unexpected error occurred");
-      console.error("Demo signin error:", err);
-    } finally {
-      setLoadingEmail(null);
-    }
-  };
-
-  return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <div className="w-full max-w-6xl">
-        <div className="text-center mb-8">
-          <div className="flex items-center justify-center mb-6">
-            <Image
-              src="/hydra-logo-multiservice.png"
-              alt="Hydra Multi Service"
-              width={400}
-              height={120}
-              className="h-auto w-full max-w-md"
-              priority
-            />
-          </div>
-          <h2 className="text-2xl font-semibold mb-2">Demo Mode</h2>
-          <p className="text-muted-foreground max-w-2xl mx-auto">
-            Select a user below to sign in instantly. Perfect for testing and
-            demonstrations.
-          </p>
-        </div>
-
-        {/* Warning Banner */}
-        <Alert className="mb-6 max-w-2xl mx-auto border-amber-500/50 bg-amber-500/10">
-          <AlertTriangle className="h-4 w-4 text-amber-500" />
-          <AlertDescription className="text-amber-900 dark:text-amber-200">
-            Demo Mode is enabled. This should only be used in development or
-            demo environments. Disable ENABLE_DEMO_MODE in production.
-          </AlertDescription>
-        </Alert>
-
-        {error && (
-          <Alert variant="destructive" className="mb-6 max-w-2xl mx-auto">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-
-        {/* Demo User Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-          {DEMO_USERS.map((user) => (
-            <DemoUserCard
-              key={user.email}
-              user={user}
-              onClick={() => handleDemoSignin(user.email)}
-              isLoading={loadingEmail === user.email}
-            />
-          ))}
-        </div>
-
-        {/* Alternative Signin Option */}
-        <div className="text-center">
-          <p className="text-sm text-muted-foreground mb-2">
-            Need to use a different account?
-          </p>
-          <Button variant="outline" asChild>
-            <Link href="/signin">Sign in with Email</Link>
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+  return <DemoSigninForm />;
 }

--- a/src/lib/demo-mode.ts
+++ b/src/lib/demo-mode.ts
@@ -2,6 +2,10 @@
  * Demo Mode Utilities
  *
  * Provides utilities for checking and managing demo mode state
+ *
+ * SECURITY: Demo mode is NEVER enabled in production, regardless of env vars.
+ * This prevents accidental exposure of the demo Credentials provider which
+ * bypasses email verification.
  */
 
 export type DemoUser = {
@@ -11,12 +15,37 @@ export type DemoUser = {
   description: string;
 };
 
+const isProduction = process.env.NODE_ENV === "production";
+const envWantsDemo = process.env.ENABLE_DEMO_MODE?.toLowerCase() === "true";
+
+// Log warning if demo mode is attempted in production
+if (isProduction && envWantsDemo) {
+  console.error(
+    "\n" +
+      "╔═══════════════════════════════════════════════════════════════════════╗\n" +
+      "║  ⚠️  SECURITY WARNING: ENABLE_DEMO_MODE=true in production!           ║\n" +
+      "║                                                                       ║\n" +
+      "║  Demo mode has been DISABLED to protect your application.             ║\n" +
+      "║  Demo mode bypasses email verification and must never run in prod.    ║\n" +
+      "║                                                                       ║\n" +
+      "║  Remove ENABLE_DEMO_MODE from your production environment variables.  ║\n" +
+      "╚═══════════════════════════════════════════════════════════════════════╝\n"
+  );
+}
+
 /**
  * Check if demo mode is enabled
  * Demo mode allows one-click signin for testing and demos
+ *
+ * IMPORTANT: Always returns false in production, regardless of env var.
+ * This is a security measure to prevent demo mode from ever running in prod.
  */
 export function isDemoModeEnabled(): boolean {
-  return process.env.ENABLE_DEMO_MODE?.toLowerCase() === "true";
+  // SECURITY: Never enable demo mode in production
+  if (isProduction) {
+    return false;
+  }
+  return envWantsDemo;
 }
 
 /**


### PR DESCRIPTION
## Summary

Prevents demo mode from running in production and consolidates demo flags into a single source of truth.

- `isDemoModeEnabled()` now always returns `false` in production, regardless of `ENABLE_DEMO_MODE` env var
- Added loud console warning if `ENABLE_DEMO_MODE=true` in production
- `/demo-signin` page now redirects to `/signin` when demo mode disabled
- Extracted client-side demo signin logic to separate component for cleaner architecture

## Why This Matters

Demo mode uses the Credentials provider which bypasses email verification. If accidentally enabled in production, attackers could sign in as any demo user and access real data. This PR ensures demo mode can **never** run in production.

## Acceptance Criteria

- [x] `isDemoModeEnabled()` returns false in production regardless of env var
- [x] Console error/warning logged if `ENABLE_DEMO_MODE=true` in production
- [x] `/demo-signin` page redirects to `/signin` in production
- [x] Demo Credentials provider not registered in production (uses `isDemoModeEnabled()`)
- [x] Build passes, existing demo mode works in development

## Files Changed

- `src/lib/demo-mode.ts` - Added production safety check and warning
- `src/app/demo-signin/page.tsx` - Converted to server component with redirect
- `src/app/demo-signin/demo-signin-form.tsx` - New client component for demo signin UI

## Testing

**Development - demo mode works:**
```bash
ENABLE_DEMO_MODE=true pnpm dev
# Visit /demo-signin → one-click login works
```

**Production build - demo mode disabled:**
```bash
NODE_ENV=production ENABLE_DEMO_MODE=true pnpm build
# Console shows security warning
# isDemoModeEnabled() returns false
# /demo-signin redirects to /signin
# Demo provider not registered
```

Closes #133