### PR TITLE
N3: Fix magic link email delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,14 +29,19 @@ BASE_URL="http://localhost:3000"
 NEXTAUTH_URL="http://localhost:3000"
 
 # ----------------------------------------
-# Email - SMTP Configuration
+# Email - Resend Configuration
 # ----------------------------------------
-# SMTP server for magic link authentication
-# Development: Use Mailtrap.io (free testing)
-# Production: Use Resend, SendGrid, or AWS SES
+# Resend API key for sending magic link emails (production)
+# Get your key from: https://resend.com/api-keys
+# The app uses Resend HTTP API (not SMTP) for reliable delivery on Vercel.
+RESEND_API_KEY=""
+
+# (Legacy) SMTP server URL — kept for local dev with Mailtrap etc.
+# Not used in production; production uses RESEND_API_KEY above.
 EMAIL_SERVER="smtp://user:pass@smtp.example.com:587"
 
 # Email address for outgoing mail
+# For production, use a verified domain in Resend (e.g., noreply@yourdomain.com)
 EMAIL_FROM="hydra@localhost.dev"
 
 # ----------------------------------------

--- a/scripts/test-magic-link-email.ts
+++ b/scripts/test-magic-link-email.ts
@@ -1,0 +1,57 @@
+/**
+ * Smoke test: send a test email via Resend HTTP API.
+ *
+ * Usage:
+ *   RESEND_API_KEY=re_xxx EMAIL_FROM=you@domain.com npx tsx scripts/test-magic-link-email.ts test@example.com
+ *
+ * This runs locally — NOT on Vercel. For Vercel testing, use the
+ * /api/debug/email route with CRON_SECRET auth.
+ */
+
+const RESEND_API_URL = "https://api.resend.com/emails";
+
+async function main() {
+  const to = process.argv[2];
+  if (!to || !to.includes("@")) {
+    console.error("Usage: npx tsx scripts/test-magic-link-email.ts <email>");
+    process.exit(1);
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error("ERROR: RESEND_API_KEY env var is required");
+    process.exit(1);
+  }
+
+  const from = process.env.EMAIL_FROM || "hydra@localhost.dev";
+
+  console.log(`Sending test email to ${to} from ${from}...`);
+
+  const res = await fetch(RESEND_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: [to],
+      subject: "[Hydra] Magic link email smoke test",
+      text: "This is a smoke test. If you see this, Resend HTTP API is working.",
+      html: "<p>This is a smoke test. If you see this, <strong>Resend HTTP API</strong> is working.</p>",
+    }),
+  });
+
+  const body = await res.text();
+  console.log(`Status: ${res.status} ${res.statusText}`);
+  console.log(`Response: ${body}`);
+
+  if (!res.ok) {
+    console.error("FAILED — see response above");
+    process.exit(1);
+  }
+
+  console.log("SUCCESS — email sent");
+}
+
+main();

--- a/src/app/api/debug/email/route.ts
+++ b/src/app/api/debug/email/route.ts
@@ -1,0 +1,73 @@
+/**
+ * DEBUG route: Test email delivery via Resend HTTP API.
+ *
+ * Protected by CRON_SECRET to prevent abuse.
+ * Remove or gate behind feature flag after incident is resolved.
+ *
+ * Usage:
+ *   curl -H "Authorization: Bearer $CRON_SECRET" \
+ *        "https://your-app.vercel.app/api/debug/email?to=test@example.com"
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sendEmailViaResend } from "@/lib/email/resend";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  // Auth: require CRON_SECRET
+  const authHeader = req.headers.get("authorization");
+  const expectedSecret = process.env.CRON_SECRET;
+
+  if (!expectedSecret || authHeader !== `Bearer ${expectedSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const to = req.nextUrl.searchParams.get("to");
+  if (!to || !to.includes("@")) {
+    return NextResponse.json(
+      { error: "Provide ?to=email@example.com" },
+      { status: 400 }
+    );
+  }
+
+  const diagnostics: Record<string, unknown> = {
+    nodeEnv: process.env.NODE_ENV,
+    hasResendApiKey: !!process.env.RESEND_API_KEY,
+    emailFrom: process.env.EMAIL_FROM || "(unset)",
+    authEmailDevMode: process.env.AUTH_EMAIL_DEV_MODE ?? "(unset)",
+    timestamp: new Date().toISOString(),
+  };
+
+  // Test DNS resolution for smtp.resend.com (informational)
+  try {
+    const dns = await import("dns");
+    const resolved = await dns.promises.resolve4("smtp.resend.com");
+    diagnostics.smtpDnsResolved = resolved;
+  } catch (err: any) {
+    diagnostics.smtpDnsError = err.message;
+  }
+
+  // Attempt Resend HTTP API send
+  try {
+    const result = await sendEmailViaResend({
+      to,
+      from: process.env.EMAIL_FROM || "hydra@localhost.dev",
+      subject: "[Hydra Debug] Email delivery test",
+      text: "If you received this, Resend HTTP API is working from Vercel.",
+      html: "<p>If you received this, <strong>Resend HTTP API</strong> is working from Vercel.</p>",
+    });
+
+    return NextResponse.json({
+      success: true,
+      emailId: result.id,
+      diagnostics,
+    });
+  } catch (err: any) {
+    diagnostics.sendError = err.message;
+    return NextResponse.json(
+      { success: false, diagnostics },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/email/env-check.ts
+++ b/src/lib/email/env-check.ts
@@ -1,0 +1,44 @@
+/**
+ * Production environment validation for email configuration.
+ *
+ * Call this at startup / module load to fail fast if required
+ * email env vars are missing in production.
+ */
+
+export function validateEmailEnv(): void {
+  const isProduction = process.env.NODE_ENV === "production";
+
+  if (!isProduction) {
+    return; // Only enforce in production
+  }
+
+  // RESEND_API_KEY is required for sending emails in production
+  if (!process.env.RESEND_API_KEY) {
+    throw new Error(
+      "[email] FATAL: RESEND_API_KEY is not set in production. Magic link emails will not send."
+    );
+  }
+
+  // EMAIL_FROM is required
+  if (!process.env.EMAIL_FROM) {
+    throw new Error(
+      "[email] FATAL: EMAIL_FROM is not set in production."
+    );
+  }
+
+  // AUTH_SECRET is required by NextAuth
+  if (!process.env.AUTH_SECRET) {
+    throw new Error(
+      "[email] FATAL: AUTH_SECRET is not set in production."
+    );
+  }
+
+  // Warn if AUTH_EMAIL_DEV_MODE is set to something other than "false" in production
+  const devModeVal = process.env.AUTH_EMAIL_DEV_MODE;
+  if (devModeVal && devModeVal.toLowerCase() !== "false") {
+    console.warn(
+      `[email] WARNING: AUTH_EMAIL_DEV_MODE="${devModeVal}" in production. ` +
+      `This flag is ignored in production (emails always send), but should be "false" or unset.`
+    );
+  }
+}

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,80 @@
+/**
+ * Resend HTTP API email sender for magic link delivery.
+ *
+ * Uses the Resend REST API instead of SMTP to avoid connection issues
+ * in serverless environments (Vercel) where outbound SMTP is unreliable.
+ */
+
+const RESEND_API_URL = "https://api.resend.com/emails";
+
+interface SendEmailOptions {
+  to: string;
+  from: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+interface ResendSuccessResponse {
+  id: string;
+}
+
+interface ResendErrorResponse {
+  statusCode: number;
+  message: string;
+  name: string;
+}
+
+/**
+ * Send an email via the Resend HTTP API.
+ *
+ * Throws on any non-2xx response with status and error message (no secrets leaked).
+ */
+export async function sendEmailViaResend(options: SendEmailOptions): Promise<ResendSuccessResponse> {
+  const apiKey = process.env.RESEND_API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      "[email] RESEND_API_KEY is not set. Cannot send email in production."
+    );
+  }
+
+  console.log("[email] Sending via Resend HTTP API", {
+    to_domain: options.to.split("@")[1] || "unknown",
+    from: options.from,
+    subject: options.subject,
+  });
+
+  const response = await fetch(RESEND_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: options.from,
+      to: [options.to],
+      subject: options.subject,
+      html: options.html,
+      text: options.text,
+    }),
+  });
+
+  const body = await response.text();
+
+  if (!response.ok) {
+    // Log enough to debug without leaking secrets
+    console.error("[email] Resend API error", {
+      status: response.status,
+      statusText: response.statusText,
+      body,
+    });
+    throw new Error(
+      `[email] Resend API returned ${response.status}: ${body}`
+    );
+  }
+
+  const result: ResendSuccessResponse = JSON.parse(body);
+  console.log("[email] Resend API success", { emailId: result.id });
+  return result;
+}


### PR DESCRIPTION
## Root Cause

Magic link emails failed on Vercel with `Error: Greeting never received` because:

1. **SMTP is unreliable in Vercel serverless** — outbound SMTP connections (port 465 implicit TLS) stall or get blocked in serverless environments.
2. Nodemailer's URL parser doesn't infer `secure: true` from port 465, causing a plaintext handshake against an SSL port.

## What Changed

- **`src/lib/email/resend.ts`** — New Resend HTTP API sender using `fetch()`. Works reliably in any serverless runtime. Structured logging on success/failure (no secrets leaked).
- **`src/lib/email/env-check.ts`** — Production env validation that throws at startup if `RESEND_API_KEY` or `EMAIL_FROM` are missing. Warns if `AUTH_EMAIL_DEV_MODE` is set oddly in prod.
- **`auth.ts`** — Replaced Nodemailer SMTP transport with `sendEmailViaResend()`. Added structured diagnostic logging on every magic link request (NODE_ENV, dev mode flag, recipient domain, API key presence).
- **`src/app/api/debug/email/route.ts`** — Protected debug endpoint (requires `CRON_SECRET`) for testing email delivery on Vercel. Includes DNS resolution check. Remove after incident resolved.
- **`scripts/test-magic-link-email.ts`** — Local smoke test script for verifying Resend API key works.
- **`.env.example`** — Documents `RESEND_API_KEY`, marks `EMAIL_SERVER` as legacy.

## Vercel Env Vars Required

| Name | Value | Environments |
|------|-------|-------------|
| `RESEND_API_KEY` | `re_...` (from resend.com/api-keys) | Production, Preview |
| `EMAIL_FROM` | `onboarding@resend.dev` | Production, Preview |

## How to Test on Vercel

1. Deploy this PR
2. Confirm `RESEND_API_KEY` and `EMAIL_FROM` are set in Vercel env vars
3. Go to the app → sign in → enter an email → check inbox for magic link
4. Verify Vercel function logs show the `[auth]` and `[email]` structured logs
5. Optionally hit `/api/debug/email?to=you@example.com` with `Authorization: Bearer $CRON_SECRET`

## Local Testing Done

- Smoke test script: `200 OK`, email delivered to gmail
- Full sign-in flow: logs confirmed end-to-end, email received, Resend dashboard shows delivery

## Rollback Plan

Revert this PR. Re-add `EMAIL_SERVER` env var and the old Nodemailer SMTP code.