### PR TITLE
#144: Add VendorUser junction table

### DIFF
--- a/prisma/migrations/20260202190000_add_vendor_user/migration.sql
+++ b/prisma/migrations/20260202190000_add_vendor_user/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "VendorUserRole" AS ENUM ('OWNER', 'STAFF', 'AGENT');
+
+-- CreateTable
+CREATE TABLE "VendorUser" (
+    "vendorId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "VendorUserRole" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VendorUser_pkey" PRIMARY KEY ("vendorId","userId")
+);
+
+-- CreateIndex
+CREATE INDEX "VendorUser_vendorId_idx" ON "VendorUser"("vendorId");
+
+-- CreateIndex
+CREATE INDEX "VendorUser_userId_idx" ON "VendorUser"("userId");
+
+-- AddForeignKey
+ALTER TABLE "VendorUser" ADD CONSTRAINT "VendorUser_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "Vendor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "VendorUser" ADD CONSTRAINT "VendorUser_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,19 @@ model AgentVendor {
   @@index([vendorId])
 }
 
+model VendorUser {
+  vendorId  String
+  userId    String
+  role      VendorUserRole
+  createdAt DateTime @default(now())
+  Vendor    Vendor   @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  User      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([vendorId, userId])
+  @@index([vendorId])
+  @@index([userId])
+}
+
 model Agreement {
   id                 String    @id
   clientId           String
@@ -517,6 +530,7 @@ model User {
   AgentClient                           AgentClient[]
   AgentVendor                           AgentVendor[]
   AuditLog                              AuditLog[]
+  VendorUser                            VendorUser[]
   Cart                                  Cart[]
   Order_Order_assignedAgentUserIdToUser Order[]       @relation("Order_assignedAgentUserIdToUser")
   Order_Order_submitterUserIdToUser     Order[]       @relation("Order_submitterUserIdToUser")
@@ -555,6 +569,7 @@ model Vendor {
   AgentVendor   AgentVendor[]
   Agreement     Agreement[]
   User          User?
+  VendorUser    VendorUser[]
   VendorProduct VendorProduct[]
   SubOrder      SubOrder[]
 
@@ -670,6 +685,12 @@ enum UserStatus {
   APPROVED
   REJECTED
   SUSPENDED
+}
+
+enum VendorUserRole {
+  OWNER
+  STAFF
+  AGENT
 }
 
 enum SubOrderStatus {


### PR DESCRIPTION
## Summary
- Adds `VendorUserRole` enum (`OWNER`, `STAFF`, `AGENT`)
- Adds `VendorUser` junction table with compound PK `(vendorId, userId)`
- Indexes on both FK columns, cascade deletes
- Follows existing `AgentVendor` pattern
- Existing `User.vendorId` kept for backward compatibility (deprecated later)

## Test plan
- [x] `prisma validate` passes
- [x] `prisma generate` succeeds
- [x] Migration applied to Neon DB without errors

Closes #144