### PR TITLE
#145: Add ClientVendor junction table

### DIFF
--- a/prisma/migrations/20260202191000_add_client_vendor/migration.sql
+++ b/prisma/migrations/20260202191000_add_client_vendor/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "ClientVendorStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+-- CreateTable
+CREATE TABLE "ClientVendor" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "vendorId" TEXT NOT NULL,
+    "status" "ClientVendorStatus" NOT NULL DEFAULT 'PENDING',
+    "approvedByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "approvedAt" TIMESTAMP(3),
+    CONSTRAINT "ClientVendor_pkey" PRIMARY KEY ("id")
+);
+-- CreateIndex
+CREATE INDEX "ClientVendor_clientId_idx" ON "ClientVendor"("clientId");
+-- CreateIndex
+CREATE INDEX "ClientVendor_vendorId_idx" ON "ClientVendor"("vendorId");
+-- CreateIndex
+CREATE INDEX "ClientVendor_status_idx" ON "ClientVendor"("status");
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientVendor_clientId_vendorId_key" ON "ClientVendor"("clientId", "vendorId");
+-- AddForeignKey
+ALTER TABLE "ClientVendor"
+ADD CONSTRAINT "ClientVendor_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- AddForeignKey
+ALTER TABLE "ClientVendor"
+ADD CONSTRAINT "ClientVendor_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "Vendor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- AddForeignKey
+ALTER TABLE "ClientVendor"
+ADD CONSTRAINT "ClientVendor_approvedByUserId_fkey" FOREIGN KEY ("approvedByUserId") REFERENCES "User"("id") ON DELETE
+SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,13 +174,14 @@ model Client {
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
 
-  AgentClient AgentClient[]
-  Agreement   Agreement[]
-  Cart        Cart[]
-  ClientStats ClientStats?
-  DriverStop  DriverStop[]
-  Order       Order[]
-  User        User?
+  AgentClient  AgentClient[]
+  Agreement    Agreement[]
+  Cart         Cart[]
+  ClientStats  ClientStats?
+  ClientVendor ClientVendor[]
+  DriverStop   DriverStop[]
+  Order        Order[]
+  User         User?
 
   @@index([region])
   @@index([email])
@@ -210,6 +211,24 @@ model ClientStats {
   updatedAt DateTime @updatedAt
 
   Client Client @relation(fields: [clientId], references: [id], onDelete: Cascade)
+}
+
+model ClientVendor {
+  id               String             @id @default(cuid())
+  clientId         String
+  vendorId         String
+  status           ClientVendorStatus @default(PENDING)
+  approvedByUserId String?
+  createdAt        DateTime           @default(now())
+  approvedAt       DateTime?
+  Client           Client             @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  Vendor           Vendor             @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  ApprovedByUser   User?              @relation("ClientVendorApprovedBy", fields: [approvedByUserId], references: [id])
+
+  @@unique([clientId, vendorId])
+  @@index([clientId])
+  @@index([vendorId])
+  @@index([status])
 }
 
 model Delivery {
@@ -530,6 +549,7 @@ model User {
   AgentClient                           AgentClient[]
   AgentVendor                           AgentVendor[]
   AuditLog                              AuditLog[]
+  ClientVendorApprovals                 ClientVendor[] @relation("ClientVendorApprovedBy")
   VendorUser                            VendorUser[]
   Cart                                  Cart[]
   Order_Order_assignedAgentUserIdToUser Order[]       @relation("Order_assignedAgentUserIdToUser")
@@ -568,6 +588,7 @@ model Vendor {
   deletedAt     DateTime?
   AgentVendor   AgentVendor[]
   Agreement     Agreement[]
+  ClientVendor  ClientVendor[]
   User          User?
   VendorUser    VendorUser[]
   VendorProduct VendorProduct[]
@@ -691,6 +712,12 @@ enum VendorUserRole {
   OWNER
   STAFF
   AGENT
+}
+
+enum ClientVendorStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 enum SubOrderStatus {


### PR DESCRIPTION
## Summary
- Adds `ClientVendorStatus` enum (`PENDING`, `APPROVED`, `REJECTED`)
- Adds `ClientVendor` model with approval tracking (`status`, `approvedByUserId`, `approvedAt`)
- Compound unique constraint on `(clientId, vendorId)`
- Indexes on `clientId`, `vendorId`, `status`
- Named relation `ClientVendorApprovedBy` on User for the approver FK

## Test plan
- [x] `prisma validate` passes
- [x] `prisma generate` succeeds
- [x] Migration applied to Neon DB without errors

Closes #145