### PR TITLE
#147: Implement status-based route gating in middleware

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -28,15 +28,27 @@ export const authConfig = {
   callbacks: {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
-      const isOnSignIn = nextUrl.pathname.startsWith("/signin");
+      const pathname = nextUrl.pathname;
 
-      if (isOnSignIn) {
+      // Public routes — always accessible
+      if (pathname === "/" || pathname.startsWith("/api/auth")) {
+        return true;
+      }
+
+      // Signin page — redirect authenticated users to dashboard
+      if (pathname.startsWith("/signin")) {
         if (isLoggedIn)
           return Response.redirect(new URL("/dashboard", nextUrl));
         return true;
       }
 
-      return isLoggedIn || nextUrl.pathname === "/";
+      // /onboarding and /pending — require authentication only (status gating in middleware)
+      if (pathname.startsWith("/onboarding") || pathname.startsWith("/pending")) {
+        return isLoggedIn;
+      }
+
+      // Everything else requires authentication
+      return isLoggedIn;
     },
   },
   providers: [], // Add providers with an empty array for now

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,14 +1,78 @@
-import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
+import { auth } from "./auth";
+import { NextResponse } from "next/server";
 
 /**
- * Minimal middleware - auth is handled in dashboard/layout.tsx
- * This exists to satisfy Next.js but does nothing
+ * Status-based route gating middleware
+ *
+ * Rules:
+ * - Public routes: /, /signin, /api/auth/* — always accessible
+ * - /onboarding, /pending — accessible to authenticated users regardless of status
+ * - /dashboard/* — only accessible to APPROVED users
+ *   - No status / undefined → redirect to /onboarding
+ *   - PENDING → redirect to /pending
+ *   - REJECTED/SUSPENDED → redirect to /pending?reason=rejected or ?reason=suspended
+ *   - APPROVED → allow through
  */
-export default function middleware(_req: NextRequest) {
-  return NextResponse.next()
-}
+export default auth((req) => {
+  const { nextUrl } = req;
+  const user = req.auth?.user;
+  const pathname = nextUrl.pathname;
+
+  // Public routes — no gating
+  if (
+    pathname === "/" ||
+    pathname.startsWith("/signin") ||
+    pathname.startsWith("/api/auth")
+  ) {
+    return NextResponse.next();
+  }
+
+  // Not authenticated — let NextAuth's authorized callback handle redirect to /signin
+  if (!user) {
+    return NextResponse.next();
+  }
+
+  const status = user.status;
+  const isDashboard = pathname.startsWith("/dashboard");
+  const isOnboarding = pathname.startsWith("/onboarding");
+  const isPending = pathname.startsWith("/pending");
+
+  // APPROVED users trying to access /onboarding or /pending — send to dashboard
+  if (status === "APPROVED" && (isOnboarding || isPending)) {
+    return NextResponse.redirect(new URL("/dashboard", nextUrl));
+  }
+
+  // Dashboard routes require APPROVED status
+  if (isDashboard) {
+    if (!status) {
+      return NextResponse.redirect(new URL("/onboarding", nextUrl));
+    }
+    if (status === "PENDING") {
+      return NextResponse.redirect(new URL("/pending", nextUrl));
+    }
+    if (status === "REJECTED") {
+      return NextResponse.redirect(
+        new URL("/pending?reason=rejected", nextUrl),
+      );
+    }
+    if (status === "SUSPENDED") {
+      return NextResponse.redirect(
+        new URL("/pending?reason=suspended", nextUrl),
+      );
+    }
+    // APPROVED — allow through
+    return NextResponse.next();
+  }
+
+  // /onboarding and /pending — allow for authenticated users
+  if (isOnboarding || isPending) {
+    return NextResponse.next();
+  }
+
+  // All other routes — allow through (existing page-level checks remain)
+  return NextResponse.next();
+});
 
 export const config = {
-  matcher: ['/dashboard/:path*'],
-}
+  matcher: ["/dashboard/:path*", "/onboarding/:path*", "/pending/:path*"],
+};

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -23,6 +23,11 @@ export default async function DashboardLayout({
     redirect("/signin");
   }
 
+  // Defense-in-depth: middleware handles this, but double-check status
+  if (!user.status || user.status !== "APPROVED") {
+    redirect(user.status === "PENDING" ? "/pending" : "/onboarding");
+  }
+
   // Fetch cart for CLIENT users
   let initialCart: Awaited<ReturnType<typeof getCart>> | undefined;
   if (user.role === "CLIENT" && user.clientId) {


### PR DESCRIPTION
## Summary
- Replaces no-op middleware with `auth()`-based status routing
- **APPROVED** → `/dashboard` (allowed)
- **PENDING** → redirected to `/pending`
- **No status** → redirected to `/onboarding`
- **REJECTED/SUSPENDED** → redirected to `/pending?reason=rejected|suspended`
- APPROVED users hitting `/onboarding` or `/pending` are redirected to `/dashboard`
- Updated `auth.config.ts` to allow `/onboarding` and `/pending` for authenticated users
- Added defense-in-depth status check in `dashboard/layout.tsx`

## Test plan
- [x] TypeScript compiles (no new errors)
- [x] No infinite redirect loops (APPROVED users can't hit /onboarding, non-approved can't hit /dashboard)
- [ ] Manual: sign in as APPROVED user → lands on /dashboard
- [ ] Manual: new user (PENDING) → redirected to /pending
- [ ] Manual: APPROVED user navigating to /onboarding → redirected to /dashboard

Closes #147