### PR TITLE
#153: Add pending approval page at /pending

### DIFF
--- a/src/app/pending/layout.tsx
+++ b/src/app/pending/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function PendingLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 to-rose-100 dark:from-slate-900 dark:to-slate-800 p-4">
+      {children}
+    </div>
+  );
+}

--- a/src/app/pending/page.tsx
+++ b/src/app/pending/page.tsx
@@ -1,0 +1,95 @@
+import { redirect } from "next/navigation";
+import { auth } from "../../../auth";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Clock, XCircle, ShieldOff } from "lucide-react";
+import { SignOutButton } from "@/components/auth/sign-out-button";
+import { RefreshButton } from "./refresh-button";
+
+export default async function PendingPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/signin");
+  }
+
+  const { status, name, email } = session.user;
+
+  // Already approved — send to dashboard
+  if (status === "APPROVED") {
+    redirect("/dashboard");
+  }
+
+  // Derive display state solely from session status (never from URL params)
+  const isRejected = status === "REJECTED";
+  const isSuspended = status === "SUSPENDED";
+
+  return (
+    <div className="w-full max-w-md space-y-4">
+      <Card>
+        <CardHeader className="text-center">
+          {isRejected ? (
+            <>
+              <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+                <XCircle className="h-6 w-6 text-destructive" />
+              </div>
+              <CardTitle>Account Not Approved</CardTitle>
+              <CardDescription>
+                Your account application has been reviewed and was not approved.
+              </CardDescription>
+            </>
+          ) : isSuspended ? (
+            <>
+              <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+                <ShieldOff className="h-6 w-6 text-destructive" />
+              </div>
+              <CardTitle>Account Suspended</CardTitle>
+              <CardDescription>
+                Your account has been suspended. Please contact an
+                administrator.
+              </CardDescription>
+            </>
+          ) : (
+            <>
+              <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                <Clock className="h-6 w-6 text-primary" />
+              </div>
+              <CardTitle>Pending Approval</CardTitle>
+              <CardDescription>
+                Your account is awaiting review by an administrator.
+              </CardDescription>
+            </>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="rounded-lg border p-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Name</span>
+              <span className="font-medium">{name || "—"}</span>
+            </div>
+            <div className="flex justify-between mt-1">
+              <span className="text-muted-foreground">Email</span>
+              <span className="font-medium">{email}</span>
+            </div>
+          </div>
+          {!isRejected && !isSuspended && (
+            <p className="text-sm text-muted-foreground text-center">
+              You&apos;ll be able to access the dashboard once your account is
+              approved.
+            </p>
+          )}
+        </CardContent>
+        <CardFooter className="flex flex-col gap-2">
+          {!isRejected && !isSuspended && <RefreshButton />}
+          <SignOutButton variant="outline" className="w-full" />
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/pending/refresh-button.tsx
+++ b/src/app/pending/refresh-button.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+
+export function RefreshButton() {
+  const router = useRouter();
+
+  return (
+    <Button className="w-full" onClick={() => router.refresh()}>
+      <RefreshCw className="mr-2 h-4 w-4" />
+      Check Status
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `/pending` page with status-aware messaging
- **PENDING**: "Awaiting approval" with clock icon + "Check Status" refresh button
- **REJECTED**: "Account not approved" with X icon
- **SUSPENDED**: "Account suspended" with shield icon
- **APPROVED**: Redirects to `/dashboard`
- Display state derived solely from `session.user.status` (not URL params)
- Displays user name and email in a summary card
- Sign out button on all states
- Minimal centered layout matching `/signin` page pattern

## Test plan
- [x] TypeScript compiles with no new errors
- [ ] Manual: PENDING user sees approval message with check status button
- [ ] Manual: REJECTED user sees rejection state
- [ ] Manual: SUSPENDED user sees suspended state
- [ ] Manual: APPROVED user hitting `/pending` redirected to `/dashboard`

Closes #153