### PR TITLE
#148: Add role selection page at /onboarding

### DIFF
--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 to-rose-100 dark:from-slate-900 dark:to-slate-800 p-4">
+      {children}
+    </div>
+  );
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,85 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth } from "../../../auth";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Store, UtensilsCrossed, Truck, Briefcase } from "lucide-react";
+
+const ROLES = [
+  {
+    key: "vendor",
+    label: "Vendor",
+    description:
+      "Supply products to restaurants and businesses. Manage your catalog, pricing, and orders.",
+    icon: Store,
+  },
+  {
+    key: "client",
+    label: "Client",
+    description:
+      "Order supplies from vendors for your restaurant or business. Browse catalogs and place orders.",
+    icon: UtensilsCrossed,
+  },
+  {
+    key: "driver",
+    label: "Driver",
+    description:
+      "Deliver orders from vendors to clients. Manage your shifts, routes, and deliveries.",
+    icon: Truck,
+  },
+  {
+    key: "agent",
+    label: "Agent",
+    description:
+      "Manage vendor and client relationships. Oversee orders, agreements, and operations.",
+    icon: Briefcase,
+  },
+] as const;
+
+export default async function OnboardingPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/signin");
+  }
+
+  if (session.user.status === "APPROVED") {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="w-full max-w-2xl space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">Welcome to Hydra</h1>
+        <p className="text-muted-foreground">
+          Select your role to get started. This determines your experience on
+          the platform.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {ROLES.map((role) => (
+          <Link key={role.key} href={`/onboarding/${role.key}`}>
+            <Card className="h-full cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02] active:scale-100">
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                    <role.icon className="h-5 w-5 text-primary" />
+                  </div>
+                  <CardTitle className="text-lg">{role.label}</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <CardDescription>{role.description}</CardDescription>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `/onboarding` page with 4 role cards: Vendor, Client, Driver, Agent
- ADMIN is never self-selectable (not shown)
- Each card navigates to `/onboarding/[role]` for the role-specific form
- APPROVED users redirected to `/dashboard`
- Unauthenticated users redirected to `/signin`
- Minimal centered layout matching `/signin` and `/pending` patterns
- Uses shadcn Card components with hover/scale transitions

## Test plan
- [x] TypeScript compiles with no new errors
- [ ] Manual: new user sees 4 role cards
- [ ] Manual: clicking a role navigates to `/onboarding/vendor` etc.
- [ ] Manual: APPROVED user hitting `/onboarding` redirected to `/dashboard`

Closes #148