### PR TITLE
#149: Add vendor onboarding form

### DIFF
--- a/src/actions/onboarding.ts
+++ b/src/actions/onboarding.ts
@@ -1,0 +1,127 @@
+"use server";
+
+import { z } from "zod";
+import { auth } from "../../auth";
+import { prisma } from "@/lib/prisma";
+import { createId } from "@paralleldrive/cuid2";
+import { logAction, AuditAction } from "@/lib/audit";
+import { revalidatePath } from "next/cache";
+
+// ─── Vendor Onboarding ────────────────────────────────────────────────────────
+
+const vendorOnboardingSchema = z.object({
+  businessName: z.string().min(1, "Business name is required").max(255),
+  contactEmail: z
+    .string()
+    .email("Invalid email")
+    .max(255)
+    .optional()
+    .or(z.literal("")),
+  contactPhone: z.string().max(50).optional(),
+  address: z.string().max(500).optional(),
+  region: z.string().max(100).optional(),
+  businessHours: z.string().max(255).optional(),
+});
+
+export type VendorOnboardingInput = z.infer<typeof vendorOnboardingSchema>;
+
+export async function submitVendorOnboarding(
+  data: VendorOnboardingInput,
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { success: false, error: "Not authenticated" };
+    }
+
+    const userId = session.user.id;
+
+    // Idempotency: check if user already submitted onboarding
+    const existingUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { status: true, role: true, onboardingData: true },
+    });
+
+    if (!existingUser) {
+      return { success: false, error: "User not found" };
+    }
+
+    if (
+      existingUser.role !== "CLIENT" ||
+      (existingUser.onboardingData !== null &&
+        existingUser.status === "PENDING")
+    ) {
+      // Already submitted — role has been set or onboarding data exists
+      if (existingUser.onboardingData !== null) {
+        return { success: false, error: "Onboarding already submitted" };
+      }
+    }
+
+    // Validate input
+    const validation = vendorOnboardingSchema.safeParse(data);
+    if (!validation.success) {
+      return {
+        success: false,
+        error: validation.error.errors[0]?.message || "Invalid input",
+      };
+    }
+
+    const validated = validation.data;
+
+    // Create Vendor + VendorUser + update User in a transaction
+    await prisma.$transaction(async (tx) => {
+      const vendorId = createId();
+
+      // Create Vendor record
+      await tx.vendor.create({
+        data: {
+          id: vendorId,
+          name: validated.businessName,
+          contactEmail: validated.contactEmail || null,
+          contactPhone: validated.contactPhone || null,
+          address: validated.address || null,
+          region: validated.region || null,
+          businessHours: validated.businessHours || null,
+        },
+      });
+
+      // Create VendorUser junction (OWNER)
+      await tx.vendorUser.create({
+        data: {
+          vendorId,
+          userId,
+          role: "OWNER",
+        },
+      });
+
+      // Update User: set role, status, store onboarding data, link vendor
+      await tx.user.update({
+        where: { id: userId },
+        data: {
+          role: "VENDOR",
+          status: "PENDING",
+          vendorId,
+          onboardingData: validated as any,
+        },
+      });
+    });
+
+    await logAction({
+      entityType: "User",
+      entityId: userId,
+      action: AuditAction.ONBOARDING_SUBMITTED,
+      diff: { role: "VENDOR", businessName: validated.businessName },
+    });
+
+    revalidatePath("/pending");
+
+    return { success: true };
+  } catch (error) {
+    console.error("Vendor onboarding error:", error);
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to submit onboarding",
+    };
+  }
+}

--- a/src/app/onboarding/vendor/page.tsx
+++ b/src/app/onboarding/vendor/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { auth } from "../../../../auth";
+import { VendorOnboardingForm } from "./vendor-onboarding-form";
+
+export default async function VendorOnboardingPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/signin");
+  }
+
+  if (session.user.status === "APPROVED") {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">
+          Vendor Registration
+        </h1>
+        <p className="text-muted-foreground">
+          Tell us about your business. This information will be reviewed by an
+          administrator.
+        </p>
+      </div>
+      <VendorOnboardingForm />
+    </div>
+  );
+}

--- a/src/app/onboarding/vendor/vendor-onboarding-form.tsx
+++ b/src/app/onboarding/vendor/vendor-onboarding-form.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  submitVendorOnboarding,
+  type VendorOnboardingInput,
+} from "@/actions/onboarding";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const schema = z.object({
+  businessName: z.string().min(1, "Business name is required").max(255),
+  contactEmail: z
+    .string()
+    .email("Invalid email")
+    .or(z.literal(""))
+    .optional(),
+  contactPhone: z.string().max(50).optional(),
+  address: z.string().max(500).optional(),
+  region: z.string().max(100).optional(),
+  businessHours: z.string().max(255).optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export function VendorOnboardingForm() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      businessName: "",
+      contactEmail: "",
+      contactPhone: "",
+      address: "",
+      region: "",
+      businessHours: "",
+    },
+  });
+
+  const onSubmit = async (data: FormValues) => {
+    setIsLoading(true);
+    try {
+      const result = await submitVendorOnboarding(
+        data as VendorOnboardingInput,
+      );
+
+      if (result.success) {
+        toast.success("Registration submitted");
+        router.push("/pending");
+      } else {
+        toast.error(result.error || "Failed to submit");
+      }
+    } catch {
+      toast.error("An unexpected error occurred");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <Card>
+          <CardContent className="pt-6 space-y-4">
+            <FormField
+              control={form.control}
+              name="businessName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Business Name *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Your company name"
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="contactEmail"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contact Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="business@example.com"
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="contactPhone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contact Phone</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="+39 xxx xxx xxxx"
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Address</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Street address"
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="region"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Region</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g. Lazio"
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="businessHours"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Business Hours</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g. Mon-Fri 8:00-18:00"
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isLoading ? "Submitting..." : "Submit Registration"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -88,6 +88,9 @@ export const AuditAction = {
   PAYMENT_RETRY_SCHEDULED: "PAYMENT_RETRY_SCHEDULED",
   PAYMENT_MARKED_REQUIRES_UPDATE: "PAYMENT_MARKED_REQUIRES_UPDATE",
   PAYMENT_MANUAL_RETRY: "PAYMENT_MANUAL_RETRY",
+
+  // Onboarding actions
+  ONBOARDING_SUBMITTED: "ONBOARDING_SUBMITTED",
 } as const;
 
 export type AuditActionType = (typeof AuditAction)[keyof typeof AuditAction];


### PR DESCRIPTION
## Summary
- Creates `/onboarding/vendor` page with registration form
- **Fields**: business name (required), contact email, phone, address, region, business hours
- **Server action** (`submitVendorOnboarding`): creates Vendor + VendorUser (OWNER) + updates User in a single transaction
- Sets user role to VENDOR, status stays PENDING, stores form data in `onboardingData`
- Idempotency check prevents duplicate submissions
- Zod validation on both client and server sides
- Audit log entry (`ONBOARDING_SUBMITTED`) on successful submission
- Redirects to `/pending` after success
- Toast notifications for success/error feedback

## Test plan
- [x] TypeScript compiles with no new errors
- [ ] Manual: navigate to /onboarding/vendor, fill form, submit
- [ ] Manual: verify Vendor + VendorUser records created in DB
- [ ] Manual: user redirected to /pending after submission
- [ ] Manual: submitting again shows "already submitted" error

Closes #149