### PR TITLE
#154: Add admin approval dashboard

### DIFF
--- a/src/app/dashboard/approvals/approvals-filters.tsx
+++ b/src/app/dashboard/approvals/approvals-filters.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, X } from "lucide-react";
+
+const STATUS_OPTIONS = [
+  { value: "PENDING", label: "Pending" },
+  { value: "APPROVED", label: "Approved" },
+  { value: "REJECTED", label: "Rejected" },
+  { value: "SUSPENDED", label: "Suspended" },
+  { value: "ALL", label: "All" },
+];
+
+const ROLE_OPTIONS = [
+  { value: "", label: "All Roles" },
+  { value: "VENDOR", label: "Vendor" },
+  { value: "CLIENT", label: "Client" },
+  { value: "DRIVER", label: "Driver" },
+  { value: "AGENT", label: "Agent" },
+];
+
+export function ApprovalsFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentStatus = searchParams.get("status") || "PENDING";
+  const currentRole = searchParams.get("role") || "";
+  const currentSearch = searchParams.get("search") || "";
+
+  const [searchQuery, setSearchQuery] = useState(currentSearch);
+  const isUserTyping = useRef(false);
+
+  // Debounced search
+  useEffect(() => {
+    if (!isUserTyping.current) return;
+    const timer = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (searchQuery) {
+        params.set("search", searchQuery);
+      } else {
+        params.delete("search");
+      }
+      params.delete("page");
+      router.push(`/dashboard/approvals?${params.toString()}`);
+      isUserTyping.current = false;
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [searchQuery, router, searchParams]);
+
+  const updateFilter = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    params.delete("page");
+    router.push(`/dashboard/approvals?${params.toString()}`);
+  };
+
+  const clearFilters = () => {
+    setSearchQuery("");
+    router.push("/dashboard/approvals");
+  };
+
+  const hasFilters =
+    currentStatus !== "PENDING" || currentRole || currentSearch;
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <div className="relative flex-1">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search by name or email..."
+          value={searchQuery}
+          onChange={(e) => {
+            isUserTyping.current = true;
+            setSearchQuery(e.target.value);
+          }}
+          className="pl-8"
+        />
+      </div>
+      <div className="flex gap-2">
+        <select
+          value={currentStatus}
+          onChange={(e) => updateFilter("status", e.target.value)}
+          className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {STATUS_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={currentRole}
+          onChange={(e) => updateFilter("role", e.target.value)}
+          className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {ROLE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {hasFilters && (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            <X className="h-4 w-4 mr-1" />
+            Clear
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/approvals/approvals-table.tsx
+++ b/src/app/dashboard/approvals/approvals-table.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { PendingUserResult } from "@/data/approvals";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { UserStatus, Role } from "@prisma/client";
+
+function statusBadgeVariant(
+  status: UserStatus,
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "APPROVED":
+      return "default";
+    case "PENDING":
+      return "secondary";
+    case "REJECTED":
+      return "destructive";
+    case "SUSPENDED":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function roleBadgeVariant(
+  role: Role,
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (role) {
+    case "ADMIN":
+      return "destructive";
+    case "VENDOR":
+      return "default";
+    case "CLIENT":
+      return "secondary";
+    case "DRIVER":
+      return "outline";
+    case "AGENT":
+      return "default";
+    default:
+      return "outline";
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function getOnboardingSummary(data: any): string {
+  if (!data) return "—";
+  return data.businessName || data.fullName || "—";
+}
+
+export function ApprovalsTable({ users }: { users: PendingUserResult[] }) {
+  const router = useRouter();
+
+  if (users.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        No users found matching the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Desktop table */}
+      <div className="hidden lg:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Business / Name</TableHead>
+              <TableHead>Submitted</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user) => (
+              <TableRow
+                key={user.id}
+                className="cursor-pointer"
+                onClick={() => router.push(`/dashboard/approvals/${user.id}`)}
+              >
+                <TableCell className="font-medium">
+                  {user.name || "—"}
+                </TableCell>
+                <TableCell className="text-muted-foreground max-w-[200px] truncate">
+                  {user.email}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={roleBadgeVariant(user.role)}>
+                    {user.role}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={statusBadgeVariant(user.status)}>
+                    {user.status}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  {getOnboardingSummary(user.onboardingData)}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {formatDate(user.createdAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="space-y-3 lg:hidden">
+        {users.map((user) => (
+          <Card
+            key={user.id}
+            className="cursor-pointer transition-colors hover:bg-muted/50"
+            onClick={() => router.push(`/dashboard/approvals/${user.id}`)}
+          >
+            <CardContent className="p-4">
+              <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                  <p className="font-medium">{user.name || user.email}</p>
+                  <p className="text-sm text-muted-foreground">{user.email}</p>
+                </div>
+                <div className="flex gap-1">
+                  <Badge variant={roleBadgeVariant(user.role)}>
+                    {user.role}
+                  </Badge>
+                  <Badge variant={statusBadgeVariant(user.status)}>
+                    {user.status}
+                  </Badge>
+                </div>
+              </div>
+              <div className="flex justify-between mt-2 text-sm text-muted-foreground">
+                <span>{getOnboardingSummary(user.onboardingData)}</span>
+                <span>{formatDate(user.createdAt)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/dashboard/approvals/page.tsx
+++ b/src/app/dashboard/approvals/page.tsx
@@ -1,0 +1,116 @@
+import { requireRole } from "@/lib/auth";
+import { fetchPendingUsers } from "@/data/approvals";
+import { PageHeader } from "@/components/shared/page-header";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { ApprovalsTable } from "./approvals-table";
+import { ApprovalsFilters } from "./approvals-filters";
+import { UserStatus, Role } from "@prisma/client";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+type SearchParams = {
+  status?: string;
+  role?: string;
+  search?: string;
+  page?: string;
+};
+
+export default async function ApprovalsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  await requireRole("ADMIN");
+
+  const params = await searchParams;
+
+  const status = (params.status as UserStatus) || "PENDING";
+  const role = params.role ? (params.role as Role) : undefined;
+  const search = params.search || undefined;
+  const page = parseInt(params.page || "1", 10);
+
+  const result = await fetchPendingUsers({
+    status: params.status === "ALL" ? undefined : status,
+    role,
+    search,
+    page,
+    pageSize: 20,
+  });
+
+  // Build pagination URLs
+  const buildUrl = (p: number) => {
+    const u = new URLSearchParams();
+    if (params.status) u.set("status", params.status);
+    if (params.role) u.set("role", params.role);
+    if (params.search) u.set("search", params.search);
+    if (p > 1) u.set("page", p.toString());
+    const qs = u.toString();
+    return `/dashboard/approvals${qs ? `?${qs}` : ""}`;
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="User Approvals"
+        subtitle={`${result.total} user${result.total !== 1 ? "s" : ""} found`}
+      />
+
+      <Card>
+        <CardHeader>
+          <ApprovalsFilters />
+        </CardHeader>
+        <CardContent>
+          <ApprovalsTable users={result.data} />
+
+          {/* Pagination */}
+          {result.totalPages > 1 && (
+            <div className="flex items-center justify-between mt-4">
+              <p className="text-sm text-muted-foreground">
+                Page {result.currentPage} of {result.totalPages}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={result.currentPage <= 1}
+                  asChild={result.currentPage > 1}
+                >
+                  {result.currentPage > 1 ? (
+                    <Link href={buildUrl(result.currentPage - 1)}>
+                      <ChevronLeft className="h-4 w-4 mr-1" />
+                      Previous
+                    </Link>
+                  ) : (
+                    <span>
+                      <ChevronLeft className="h-4 w-4 mr-1" />
+                      Previous
+                    </span>
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={result.currentPage >= result.totalPages}
+                  asChild={result.currentPage < result.totalPages}
+                >
+                  {result.currentPage < result.totalPages ? (
+                    <Link href={buildUrl(result.currentPage + 1)}>
+                      Next
+                      <ChevronRight className="h-4 w-4 ml-1" />
+                    </Link>
+                  ) : (
+                    <span>
+                      Next
+                      <ChevronRight className="h-4 w-4 ml-1" />
+                    </span>
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/data/approvals.ts
+++ b/src/data/approvals.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { UserStatus, Role } from "@prisma/client";
+
+export type ApprovalFilters = {
+  status?: UserStatus;
+  role?: Role;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export type PendingUserResult = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: Role;
+  status: UserStatus;
+  onboardingData: any;
+  createdAt: string;
+};
+
+export async function fetchPendingUsers(
+  filters: ApprovalFilters = {},
+): Promise<{
+  data: PendingUserResult[];
+  total: number;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+}> {
+  await requireRole("ADMIN");
+
+  const { status = "PENDING", role, search, page = 1, pageSize = 20 } = filters;
+
+  const where: any = {
+    deletedAt: null,
+  };
+
+  if (status) {
+    where.status = status;
+  }
+
+  if (role) {
+    where.role = role;
+  }
+
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: "insensitive" } },
+      { email: { contains: search, mode: "insensitive" } },
+    ];
+  }
+
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        status: true,
+        onboardingData: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  return {
+    data: users.map((u) => ({
+      ...u,
+      createdAt: u.createdAt.toISOString(),
+    })),
+    total,
+    currentPage: page,
+    totalPages: Math.ceil(total / pageSize),
+    pageSize,
+  };
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -15,6 +15,7 @@ import {
   UserCog,
   CreditCard,
   AlertCircle,
+  ShieldCheck,
   type LucideIcon,
 } from "lucide-react";
 
@@ -52,6 +53,11 @@ export function getNavItems(role: Role): NavItem[] {
           label: "Agents",
           href: "/dashboard/agents",
           icon: UserCog,
+        },
+        {
+          label: "Approvals",
+          href: "/dashboard/approvals",
+          icon: ShieldCheck,
         },
         {
           label: "Catalog",


### PR DESCRIPTION
## Summary
- Creates `/dashboard/approvals` page (ADMIN-only via `requireRole`)
- **Table columns**: name, email, role, status, business/contact name, submitted date
- **Filters**: status (PENDING by default, all statuses available), role, debounced search
- URL-based filter state, server-side pagination (20 per page)
- Desktop table + mobile card layout (responsive)
- Row click navigates to `/dashboard/approvals/[userId]` for detail view (#157)
- Data loader `fetchPendingUsers` with Prisma pagination and role protection
- Adds "Approvals" nav item with ShieldCheck icon in admin sidebar

## Test plan
- [x] TypeScript compiles with no new errors
- [ ] Manual: sign in as ADMIN, navigate to Approvals in sidebar
- [ ] Manual: verify PENDING users show by default
- [ ] Manual: test status/role filters and search
- [ ] Manual: non-admin users cannot access the page

Closes #154