### PR TITLE
N3: Admin approve/reject/suspend/reactivate server actions

### DIFF
--- a/src/actions/admin-approvals.ts
+++ b/src/actions/admin-approvals.ts
@@ -1,0 +1,191 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { logAction, AuditAction } from "@/lib/audit";
+import { revalidatePath } from "next/cache";
+
+type ActionResult = { success: true } | { success: false; error: string };
+
+export async function approveUser(userId: string): Promise<ActionResult> {
+  try {
+    const admin = await requireRole("ADMIN");
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, status: true },
+    });
+
+    if (!user) {
+      return { success: false, error: "User not found" };
+    }
+
+    if (user.status === "APPROVED") {
+      return { success: false, error: "User is already approved" };
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        status: "APPROVED",
+        approvedAt: new Date(),
+        approvedByUserId: admin.id,
+      },
+    });
+
+    await logAction({
+      entityType: "User",
+      entityId: userId,
+      action: AuditAction.USER_APPROVED,
+      diff: { previousStatus: user.status },
+    });
+
+    revalidatePath("/dashboard/approvals");
+    revalidatePath(`/dashboard/approvals/${userId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error approving user:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to approve user",
+    };
+  }
+}
+
+export async function rejectUser(
+  userId: string,
+  reason?: string,
+): Promise<ActionResult> {
+  try {
+    await requireRole("ADMIN");
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, status: true },
+    });
+
+    if (!user) {
+      return { success: false, error: "User not found" };
+    }
+
+    if (user.status === "REJECTED") {
+      return { success: false, error: "User is already rejected" };
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { status: "REJECTED" },
+    });
+
+    await logAction({
+      entityType: "User",
+      entityId: userId,
+      action: AuditAction.USER_REJECTED,
+      diff: { previousStatus: user.status, reason: reason || null },
+    });
+
+    revalidatePath("/dashboard/approvals");
+    revalidatePath(`/dashboard/approvals/${userId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error rejecting user:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to reject user",
+    };
+  }
+}
+
+export async function suspendUser(
+  userId: string,
+  reason?: string,
+): Promise<ActionResult> {
+  try {
+    await requireRole("ADMIN");
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, status: true },
+    });
+
+    if (!user) {
+      return { success: false, error: "User not found" };
+    }
+
+    if (user.status === "SUSPENDED") {
+      return { success: false, error: "User is already suspended" };
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { status: "SUSPENDED" },
+    });
+
+    await logAction({
+      entityType: "User",
+      entityId: userId,
+      action: AuditAction.USER_SUSPENDED,
+      diff: { previousStatus: user.status, reason: reason || null },
+    });
+
+    revalidatePath("/dashboard/approvals");
+    revalidatePath(`/dashboard/approvals/${userId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error suspending user:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to suspend user",
+    };
+  }
+}
+
+export async function reactivateUser(userId: string): Promise<ActionResult> {
+  try {
+    const admin = await requireRole("ADMIN");
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, status: true },
+    });
+
+    if (!user) {
+      return { success: false, error: "User not found" };
+    }
+
+    if (user.status === "APPROVED") {
+      return { success: false, error: "User is already active" };
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        status: "APPROVED",
+        approvedAt: new Date(),
+        approvedByUserId: admin.id,
+      },
+    });
+
+    await logAction({
+      entityType: "User",
+      entityId: userId,
+      action: AuditAction.USER_REACTIVATED,
+      diff: { previousStatus: user.status },
+    });
+
+    revalidatePath("/dashboard/approvals");
+    revalidatePath(`/dashboard/approvals/${userId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error reactivating user:", error);
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to reactivate user",
+    };
+  }
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -91,6 +91,12 @@ export const AuditAction = {
 
   // Onboarding actions
   ONBOARDING_SUBMITTED: "ONBOARDING_SUBMITTED",
+
+  // User approval actions
+  USER_APPROVED: "USER_APPROVED",
+  USER_REJECTED: "USER_REJECTED",
+  USER_SUSPENDED: "USER_SUSPENDED",
+  USER_REACTIVATED: "USER_REACTIVATED",
 } as const;
 
 export type AuditActionType = (typeof AuditAction)[keyof typeof AuditAction];
@@ -190,7 +196,7 @@ export async function logBulkActions(
     entityId: string;
     action: AuditActionType;
     diff?: Record<string, any> | null;
-  }>
+  }>,
 ): Promise<void> {
   try {
     const user = await currentUser();
@@ -236,7 +242,7 @@ export async function getAuditLogs(
   options?: {
     limit?: number;
     includeUser?: boolean;
-  }
+  },
 ) {
   const { limit, includeUser = true } = options || {};
 


### PR DESCRIPTION
## Summary
- Add 4 server actions for admin user management: `approveUser`, `rejectUser`, `suspendUser`, `reactivateUser`
- All actions require ADMIN role via `requireRole("ADMIN")`
- Each action validates current status (idempotency guard), updates user, and creates an audit log entry
- Add `USER_APPROVED`, `USER_REJECTED`, `USER_SUSPENDED`, `USER_REACTIVATED` to audit action constants

## Test plan
- [ ] Verify TypeScript compiles without errors on new files
- [ ] Call `approveUser` on a PENDING user — status becomes APPROVED, approvedAt and approvedByUserId set
- [ ] Call `rejectUser` on a PENDING user with reason — status becomes REJECTED, audit diff includes reason
- [ ] Call `suspendUser` on an APPROVED user — status becomes SUSPENDED
- [ ] Call `reactivateUser` on a SUSPENDED user — status becomes APPROVED
- [ ] Verify idempotency: calling `approveUser` on already-APPROVED user returns error

Closes #155