### PR TITLE
N3: Admin approval detail page /dashboard/approvals/[userId]

### DIFF
--- a/src/app/dashboard/approvals/[userId]/status-actions.tsx
+++ b/src/app/dashboard/approvals/[userId]/status-actions.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { UserStatus } from "@prisma/client";
+import {
+  approveUser,
+  rejectUser,
+  suspendUser,
+  reactivateUser,
+} from "@/actions/admin-approvals";
+import { toast } from "sonner";
+import { CheckCircle, XCircle, ShieldBan, RotateCcw } from "lucide-react";
+
+export function StatusActions({
+  userId,
+  currentStatus,
+}: {
+  userId: string;
+  currentStatus: UserStatus;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleAction = (
+    action: () => Promise<{ success: boolean; error?: string }>,
+    successMessage: string,
+  ) => {
+    startTransition(async () => {
+      const result = await action();
+      if (result.success) {
+        toast.success(successMessage);
+      } else {
+        toast.error("error" in result ? result.error : "Action failed");
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {currentStatus !== "APPROVED" && (
+        <Button
+          size="sm"
+          disabled={isPending}
+          onClick={() =>
+            handleAction(
+              () => approveUser(userId),
+              "User approved successfully",
+            )
+          }
+        >
+          <CheckCircle className="h-4 w-4 mr-1" />
+          Approve
+        </Button>
+      )}
+
+      {currentStatus !== "REJECTED" && (
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={isPending}
+          onClick={() =>
+            handleAction(() => rejectUser(userId), "User rejected")
+          }
+        >
+          <XCircle className="h-4 w-4 mr-1" />
+          Reject
+        </Button>
+      )}
+
+      {currentStatus === "APPROVED" && (
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={isPending}
+          onClick={() =>
+            handleAction(() => suspendUser(userId), "User suspended")
+          }
+        >
+          <ShieldBan className="h-4 w-4 mr-1" />
+          Suspend
+        </Button>
+      )}
+
+      {(currentStatus === "SUSPENDED" || currentStatus === "REJECTED") && (
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={() =>
+            handleAction(() => reactivateUser(userId), "User reactivated")
+          }
+        >
+          <RotateCcw className="h-4 w-4 mr-1" />
+          Reactivate
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/approvals/[userId]/vendor-user-links.tsx
+++ b/src/app/dashboard/approvals/[userId]/vendor-user-links.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  unlinkVendorUser,
+  updateVendorUserRole,
+} from "@/actions/admin-linking";
+import { toast } from "sonner";
+import { Trash2 } from "lucide-react";
+
+type VendorUserLink = {
+  vendorId: string;
+  role: string;
+  Vendor: { id: string; name: string };
+};
+
+export function VendorUserLinks({
+  userId,
+  links,
+}: {
+  userId: string;
+  links: VendorUserLink[];
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  if (links.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No vendor memberships found.
+      </p>
+    );
+  }
+
+  const handleUnlink = (vendorId: string, vendorName: string) => {
+    startTransition(async () => {
+      const result = await unlinkVendorUser({ userId, vendorId });
+      if (result.success) {
+        toast.success(`Removed from ${vendorName}`);
+      } else {
+        toast.error("error" in result ? result.error : "Failed to unlink");
+      }
+    });
+  };
+
+  const handleRoleChange = (
+    vendorId: string,
+    newRole: "OWNER" | "STAFF" | "AGENT",
+  ) => {
+    startTransition(async () => {
+      const result = await updateVendorUserRole({
+        userId,
+        vendorId,
+        role: newRole,
+      });
+      if (result.success) {
+        toast.success(`Role updated to ${newRole}`);
+      } else {
+        toast.error("error" in result ? result.error : "Failed to update role");
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      {links.map((link) => (
+        <div
+          key={link.vendorId}
+          className="flex items-center justify-between rounded-md border p-3"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-medium">{link.Vendor.name}</span>
+            <Badge variant="outline">{link.role}</Badge>
+          </div>
+          <div className="flex items-center gap-2">
+            <select
+              disabled={isPending}
+              value={link.role}
+              onChange={(e) =>
+                handleRoleChange(
+                  link.vendorId,
+                  e.target.value as "OWNER" | "STAFF" | "AGENT",
+                )
+              }
+              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option value="OWNER">OWNER</option>
+              <option value="STAFF">STAFF</option>
+              <option value="AGENT">AGENT</option>
+            </select>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={isPending}
+              onClick={() => handleUnlink(link.vendorId, link.Vendor.name)}
+            >
+              <Trash2 className="h-4 w-4 text-destructive" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/data/approvals.ts
+++ b/src/data/approvals.ts
@@ -22,6 +22,73 @@ export type PendingUserResult = {
   createdAt: string;
 };
 
+export type ApprovalDetailResult = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: Role;
+  status: UserStatus;
+  onboardingData: any;
+  createdAt: string;
+  approvedAt: string | null;
+  approvedByUserId: string | null;
+  agentCode: string | null;
+  vendorId: string | null;
+  clientId: string | null;
+  driverId: string | null;
+  Vendor: { id: string; name: string } | null;
+  Client: { id: string; name: string } | null;
+  Driver: { id: string; name: string } | null;
+  VendorUser: Array<{
+    vendorId: string;
+    role: string;
+    Vendor: { id: string; name: string };
+  }>;
+};
+
+export async function fetchApprovalDetail(
+  userId: string,
+): Promise<ApprovalDetailResult | null> {
+  await requireRole("ADMIN");
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId, deletedAt: null },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      status: true,
+      onboardingData: true,
+      createdAt: true,
+      approvedAt: true,
+      approvedByUserId: true,
+      agentCode: true,
+      vendorId: true,
+      clientId: true,
+      driverId: true,
+      Vendor: { select: { id: true, name: true } },
+      Client: { select: { id: true, name: true } },
+      Driver: { select: { id: true, name: true } },
+      VendorUser: {
+        select: {
+          vendorId: true,
+          role: true,
+          Vendor: { select: { id: true, name: true } },
+        },
+      },
+    },
+  });
+
+  if (!user) return null;
+
+  return {
+    ...user,
+    createdAt: user.createdAt.toISOString(),
+    approvedAt: user.approvedAt?.toISOString() ?? null,
+  };
+}
+
 export async function fetchPendingUsers(
   filters: ApprovalFilters = {},
 ): Promise<{


### PR DESCRIPTION
## Summary
- Add `fetchApprovalDetail` data loader in `src/data/approvals.ts` — fetches user with Vendor, Client, Driver, and VendorUser relations
- Server page at `/dashboard/approvals/[userId]` shows:
  - User summary card (role, status badge, dates, linked entities)
  - Status controls card (approve/reject/suspend/reactivate via #155 actions)
  - Onboarding data card (renders all submitted fields from any role's form)
  - Vendor memberships card (VENDOR role only — role change dropdown + unlink via #156 actions)
- All actions use `useTransition` for optimistic pending state and sonner toasts for feedback
- ADMIN-only via `requireRole("ADMIN")`

## Test plan
- [ ] Navigate from approvals list → click a user row → detail page loads
- [ ] Verify user summary shows correct role, status, dates
- [ ] Approve a PENDING user → status badge updates, toast shows success
- [ ] Reject a user → status updates, reactivate button appears
- [ ] Suspend an APPROVED user → status updates
- [ ] Reactivate a suspended/rejected user → status returns to APPROVED
- [ ] For VENDOR users: vendor memberships card shows, role dropdown works, unlink works
- [ ] Non-VENDOR users: vendor memberships card hidden
- [ ] Back button returns to approvals list
- [ ] 404 for non-existent userId

Closes #157