### PR TITLE
fix: update 8 test files to match current source code

### DIFF
--- a/src/lib/__tests__/nav.test.ts
+++ b/src/lib/__tests__/nav.test.ts
@@ -1,129 +1,137 @@
-import { describe, it, expect } from 'vitest'
-import { getNavItems, getUserInitials, getRoleLabel } from '../nav'
+import { describe, it, expect } from "vitest";
+import { getNavItems, getUserInitials, getRoleLabel } from "../nav";
 
-describe('nav utilities', () => {
-  describe('getNavItems', () => {
-    it('should return correct nav items for ADMIN', () => {
-      const items = getNavItems('ADMIN')
+describe("nav utilities", () => {
+  describe("getNavItems", () => {
+    it("should return correct nav items for ADMIN", () => {
+      const items = getNavItems("ADMIN");
 
-      expect(items).toHaveLength(7)
+      expect(items).toHaveLength(12);
       expect(items.map((item) => item.label)).toEqual([
-        'Dashboard',
-        'Vendors',
-        'Clients',
-        'Catalog',
-        'Orders',
-        'Smistamento Ordini',
-        'Reports',
-      ])
+        "Dashboard",
+        "Vendors",
+        "Clients",
+        "Agents",
+        "Approvals",
+        "Catalog",
+        "Orders",
+        "Deliveries",
+        "Failed Payments",
+        "Shifts",
+        "Smistamento Ordini",
+        "Reports",
+      ]);
 
-      expect(items[0].href).toBe('/dashboard')
-      expect(items[1].href).toBe('/dashboard/vendors')
-    })
+      expect(items[0].href).toBe("/dashboard");
+      expect(items[1].href).toBe("/dashboard/vendors");
+    });
 
-    it('should return correct nav items for AGENT', () => {
-      const items = getNavItems('AGENT')
+    it("should return correct nav items for AGENT", () => {
+      const items = getNavItems("AGENT");
 
-      expect(items).toHaveLength(7)
+      expect(items).toHaveLength(10);
       expect(items.map((item) => item.label)).toEqual([
-        'Dashboard',
-        'Vendors',
-        'Clients',
-        'Catalog',
-        'Orders',
-        'Smistamento Ordini',
-        'Reports',
-      ])
-    })
+        "Dashboard",
+        "Vendors",
+        "Clients",
+        "Catalog",
+        "Orders",
+        "Deliveries",
+        "Failed Payments",
+        "Shifts",
+        "Smistamento Ordini",
+        "Reports",
+      ]);
+    });
 
-    it('should return correct nav items for VENDOR', () => {
-      const items = getNavItems('VENDOR')
+    it("should return correct nav items for VENDOR", () => {
+      const items = getNavItems("VENDOR");
 
-      expect(items).toHaveLength(3)
+      expect(items).toHaveLength(4);
       expect(items.map((item) => item.label)).toEqual([
-        'Dashboard',
-        'My Inventory',
-        'Orders',
-      ])
+        "Dashboard",
+        "My Inventory",
+        "Orders",
+        "Settings",
+      ]);
 
-      expect(items[1].href).toBe('/dashboard/inventory')
-    })
+      expect(items[1].href).toBe("/dashboard/inventory");
+    });
 
-    it('should return correct nav items for CLIENT', () => {
-      const items = getNavItems('CLIENT')
+    it("should return correct nav items for CLIENT", () => {
+      const items = getNavItems("CLIENT");
 
-      expect(items).toHaveLength(5)
+      expect(items).toHaveLength(5);
       expect(items.map((item) => item.label)).toEqual([
-        'Dashboard',
-        'Catalog',
-        'My Agreements',
-        'My Cart',
-        'Orders',
-      ])
+        "Dashboard",
+        "Catalog",
+        "My Cart",
+        "Orders",
+        "Payment Methods",
+      ]);
 
-      expect(items[2].href).toBe('/dashboard/agreements')
-      expect(items[3].href).toBe('/dashboard/cart')
-    })
+      expect(items[2].href).toBe("/dashboard/cart");
+    });
 
-    it('should include icons for all nav items', () => {
-      const adminItems = getNavItems('ADMIN')
-      const vendorItems = getNavItems('VENDOR')
-      const clientItems = getNavItems('CLIENT')
+    it("should include icons for all nav items", () => {
+      const adminItems = getNavItems("ADMIN");
+      const vendorItems = getNavItems("VENDOR");
+      const clientItems = getNavItems("CLIENT");
 
       adminItems.forEach((item) => {
-        expect(item.icon).toBeDefined()
-        expect(typeof item.icon).toBe('object') // Lucide icons are React components (objects)
-      })
+        expect(item.icon).toBeDefined();
+        expect(typeof item.icon).toBe("object"); // Lucide icons are React components (objects)
+      });
 
       vendorItems.forEach((item) => {
-        expect(item.icon).toBeDefined()
-      })
+        expect(item.icon).toBeDefined();
+      });
 
       clientItems.forEach((item) => {
-        expect(item.icon).toBeDefined()
-      })
-    })
+        expect(item.icon).toBeDefined();
+      });
+    });
 
-    it('should return empty array for invalid role', () => {
+    it("should return empty array for invalid role", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const items = getNavItems('INVALID' as any)
-      expect(items).toEqual([])
-    })
-  })
+      const items = getNavItems("INVALID" as any);
+      expect(items).toEqual([]);
+    });
+  });
 
-  describe('getUserInitials', () => {
-    it('should return initials from full name', () => {
-      expect(getUserInitials('John Doe', 'john@example.com')).toBe('JD')
-      expect(getUserInitials('Alice Smith', 'alice@example.com')).toBe('AS')
-    })
+  describe("getUserInitials", () => {
+    it("should return initials from full name", () => {
+      expect(getUserInitials("John Doe", "john@example.com")).toBe("JD");
+      expect(getUserInitials("Alice Smith", "alice@example.com")).toBe("AS");
+    });
 
-    it('should return first two letters from single name', () => {
-      expect(getUserInitials('Admin', 'admin@example.com')).toBe('AD')
-      expect(getUserInitials('Bob', 'bob@example.com')).toBe('BO')
-    })
+    it("should return first two letters from single name", () => {
+      expect(getUserInitials("Admin", "admin@example.com")).toBe("AD");
+      expect(getUserInitials("Bob", "bob@example.com")).toBe("BO");
+    });
 
-    it('should fall back to email if no name', () => {
-      expect(getUserInitials(null, 'john@example.com')).toBe('JO')
-      expect(getUserInitials(undefined, 'admin@hydra.local')).toBe('AD')
-    })
+    it("should fall back to email if no name", () => {
+      expect(getUserInitials(null, "john@example.com")).toBe("JO");
+      expect(getUserInitials(undefined, "admin@hydra.local")).toBe("AD");
+    });
 
-    it('should return U as last fallback', () => {
-      expect(getUserInitials(null, '')).toBe('U')
-      expect(getUserInitials(undefined, '')).toBe('U')
-    })
+    it("should return U as last fallback", () => {
+      expect(getUserInitials(null, "")).toBe("U");
+      expect(getUserInitials(undefined, "")).toBe("U");
+    });
 
-    it('should uppercase initials', () => {
-      expect(getUserInitials('john doe', 'test@example.com')).toBe('JD')
-      expect(getUserInitials('alice', 'test@example.com')).toBe('AL')
-    })
-  })
+    it("should uppercase initials", () => {
+      expect(getUserInitials("john doe", "test@example.com")).toBe("JD");
+      expect(getUserInitials("alice", "test@example.com")).toBe("AL");
+    });
+  });
 
-  describe('getRoleLabel', () => {
-    it('should return correct label for each role', () => {
-      expect(getRoleLabel('ADMIN')).toBe('Administrator')
-      expect(getRoleLabel('AGENT')).toBe('Agent')
-      expect(getRoleLabel('VENDOR')).toBe('Vendor')
-      expect(getRoleLabel('CLIENT')).toBe('Client')
-    })
-  })
-})
+  describe("getRoleLabel", () => {
+    it("should return correct label for each role", () => {
+      expect(getRoleLabel("ADMIN")).toBe("Administrator");
+      expect(getRoleLabel("AGENT")).toBe("Agent");
+      expect(getRoleLabel("VENDOR")).toBe("Vendor");
+      expect(getRoleLabel("CLIENT")).toBe("Client");
+    });
+  });
+});

--- a/tests/cart/cart-validation.test.ts
+++ b/tests/cart/cart-validation.test.ts
@@ -26,7 +26,7 @@ describe("validateCartForCurrentUser", () => {
       vi.mocked(currentUser).mockResolvedValue(null);
 
       await expect(validateCartForCurrentUser()).rejects.toThrow(
-        "Unauthorized: User not authenticated"
+        "Unauthorized: User not authenticated",
       );
     });
 
@@ -39,10 +39,12 @@ describe("validateCartForCurrentUser", () => {
         name: "Agent",
         agentCode: "AGENT1",
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       await expect(validateCartForCurrentUser()).rejects.toThrow(
-        "Unauthorized: Only CLIENT users can validate carts for checkout"
+        "Unauthorized: Only CLIENT users can validate carts for checkout",
       );
     });
 
@@ -55,10 +57,12 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       await expect(validateCartForCurrentUser()).rejects.toThrow(
-        "Unauthorized: User does not have an associated client account"
+        "Unauthorized: User does not have an associated client account",
       );
     });
   });
@@ -73,6 +77,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -82,7 +88,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [],
+        CartItem: [],
       } as any);
 
       const result = await validateCartForCurrentUser();
@@ -102,6 +108,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue(null);
@@ -125,6 +133,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -134,7 +144,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -143,14 +153,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 0,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -184,6 +194,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -193,7 +205,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -202,14 +214,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: -1,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -233,6 +245,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -242,7 +256,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -251,14 +265,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 5,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -292,6 +306,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -301,7 +317,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -310,14 +326,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: null,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -340,6 +356,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -349,7 +367,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -358,14 +376,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 10,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -390,6 +408,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -399,7 +419,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -408,14 +428,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 100,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -431,7 +451,8 @@ describe("validateCartForCurrentUser", () => {
         cartItemId: "item1",
         severity: "error",
         code: "INVALID_QUANTITY",
-        message: "Invalid quantity in cart. Please remove this item and re-add it.",
+        message:
+          "Invalid quantity in cart. Please remove this item and re-add it.",
         quantityRequested: 0,
       });
     });
@@ -445,6 +466,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -454,7 +477,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -463,14 +486,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 100,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -496,6 +519,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -505,7 +530,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -514,7 +539,7 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: null,
+            VendorProduct: null,
           },
         ],
       } as any);
@@ -542,6 +567,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -551,7 +578,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -560,14 +587,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 10,
               isActive: true,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: null,
+              Vendor: null,
             },
           },
         ],
@@ -599,6 +626,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -608,7 +637,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -617,14 +646,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 10,
               isActive: false,
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },
@@ -660,6 +689,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -669,7 +700,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -678,14 +709,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 0,
               isActive: true,
-              product: {
+              Product: {
                 name: "Product 1",
               },
-              vendor: {
+              Vendor: {
                 name: "Vendor 1",
               },
             },
@@ -698,14 +729,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 2000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp2",
               stockQty: 5,
               isActive: true,
-              product: {
+              Product: {
                 name: "Product 2",
               },
-              vendor: {
+              Vendor: {
                 name: "Vendor 2",
               },
             },
@@ -730,6 +761,8 @@ describe("validateCartForCurrentUser", () => {
         name: "Client",
         agentCode: null,
         vendorId: null,
+        driverId: null,
+        status: "APPROVED",
       });
 
       vi.mocked(prisma.cart.findFirst).mockResolvedValue({
@@ -739,7 +772,7 @@ describe("validateCartForCurrentUser", () => {
         status: "ACTIVE",
         createdAt: new Date(),
         updatedAt: new Date(),
-        items: [
+        CartItem: [
           {
             id: "item1",
             cartId: "cart1",
@@ -748,14 +781,14 @@ describe("validateCartForCurrentUser", () => {
             unitPriceCents: 1000,
             createdAt: new Date(),
             updatedAt: new Date(),
-            vendorProduct: {
+            VendorProduct: {
               id: "vp1",
               stockQty: 100,
               isActive: false, // Only a warning
-              product: {
+              Product: {
                 name: "Test Product",
               },
-              vendor: {
+              Vendor: {
                 name: "Test Vendor",
               },
             },

--- a/tests/cart/recalc.test.ts
+++ b/tests/cart/recalc.test.ts
@@ -1,151 +1,161 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { recalcCartPricesForUser } from '@/data/cart-recalc'
-import { prisma } from '@/lib/prisma'
-import { currentUser } from '@/lib/auth'
-import { getEffectivePriceCents } from '@/lib/pricing'
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { recalcCartPricesForUser } from "@/data/cart-recalc";
+import { prisma } from "@/lib/prisma";
+import { currentUser } from "@/lib/auth";
+import { getEffectivePriceCents } from "@/lib/pricing";
 
 // Mock dependencies
-vi.mock('@/lib/prisma', () => ({
+vi.mock("@/lib/prisma", () => ({
   prisma: {
     $transaction: vi.fn(),
     cart: {
       findFirst: vi.fn(),
     },
   },
-}))
+}));
 
-vi.mock('@/lib/auth', () => ({
+vi.mock("@/lib/auth", () => ({
   currentUser: vi.fn(),
-}))
+}));
 
-vi.mock('@/lib/pricing', () => ({
+vi.mock("@/lib/pricing", () => ({
   getEffectivePriceCents: vi.fn(),
-}))
+}));
 
-vi.mock('next/cache', () => ({
+vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
-}))
+}));
 
-describe('recalcCartPricesForUser', () => {
+describe("recalcCartPricesForUser", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  it('should throw error when user is not authenticated', async () => {
-    vi.mocked(currentUser).mockResolvedValue(null)
+  it("should throw error when user is not authenticated", async () => {
+    vi.mocked(currentUser).mockResolvedValue(null);
 
-    await expect(recalcCartPricesForUser()).rejects.toThrow('Unauthorized')
-  })
+    await expect(recalcCartPricesForUser()).rejects.toThrow("Unauthorized");
+  });
 
-  it('should throw error when user is not CLIENT role', async () => {
+  it("should throw error when user is not CLIENT role", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'agent@test.com',
-      role: 'AGENT',
+      id: "user1",
+      email: "agent@test.com",
+      role: "AGENT",
       clientId: null,
-      name: 'Agent',
-      agentCode: 'AGENT1',
+      name: "Agent",
+      agentCode: "AGENT1",
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
     await expect(recalcCartPricesForUser()).rejects.toThrow(
-      'Only CLIENT users can recalculate cart prices'
-    )
-  })
+      "Only CLIENT users can recalculate cart prices",
+    );
+  });
 
-  it('should throw error when user has no clientId', async () => {
+  it("should throw error when user has no clientId", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
       clientId: null,
-      name: 'Client',
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
     await expect(recalcCartPricesForUser()).rejects.toThrow(
-      'User does not have an associated client'
-    )
-  })
+      "User does not have an associated client",
+    );
+  });
 
-  it('should return empty diffs when cart is empty', async () => {
+  it("should return empty diffs when cart is empty", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
     // Mock cart query with empty items
     vi.mocked(prisma.cart.findFirst).mockResolvedValue({
-      id: 'cart1',
-      clientId: 'client1',
-      createdByUserId: 'user1',
-      status: 'ACTIVE',
+      id: "cart1",
+      clientId: "client1",
+      createdByUserId: "user1",
+      status: "ACTIVE",
       createdAt: new Date(),
       updatedAt: new Date(),
-      items: [],
-    } as any)
+      CartItem: [],
+    } as any);
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
-    expect(diffs).toEqual([])
-  })
+    expect(diffs).toEqual([]);
+  });
 
-  it('should return empty diffs when no cart exists', async () => {
+  it("should return empty diffs when no cart exists", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
     // Mock cart query to return null
-    vi.mocked(prisma.cart.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.cart.findFirst).mockResolvedValue(null);
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
-    expect(diffs).toEqual([])
-  })
+    expect(diffs).toEqual([]);
+  });
 
-  it('should return diffs with unchanged prices', async () => {
+  it("should return diffs with unchanged prices", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
-    vi.mocked(getEffectivePriceCents).mockResolvedValue(1000)
+    vi.mocked(getEffectivePriceCents).mockResolvedValue(1000);
 
-    const mockUpdate = vi.fn()
+    const mockUpdate = vi.fn();
 
     // Mock cart query
     vi.mocked(prisma.cart.findFirst).mockResolvedValue({
-      id: 'cart1',
-      clientId: 'client1',
-      createdByUserId: 'user1',
-      status: 'ACTIVE',
+      id: "cart1",
+      clientId: "client1",
+      createdByUserId: "user1",
+      status: "ACTIVE",
       createdAt: new Date(),
       updatedAt: new Date(),
-      items: [
+      CartItem: [
         {
-          id: 'item1',
-          vendorProductId: 'vp1',
+          id: "item1",
+          vendorProductId: "vp1",
           unitPriceCents: 1000, // Same as current price
         },
       ],
-    } as any)
+    } as any);
 
     // Mock transaction
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
@@ -153,60 +163,62 @@ describe('recalcCartPricesForUser', () => {
         cartItem: {
           update: mockUpdate,
         },
-      }
-      return callback(tx)
-    })
+      };
+      return callback(tx);
+    });
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
-    expect(diffs).toHaveLength(1)
+    expect(diffs).toHaveLength(1);
     expect(diffs[0]).toEqual({
-      itemId: 'item1',
+      itemId: "item1",
       oldPriceCents: 1000,
       newPriceCents: 1000,
-    })
+    });
 
     // Should not update when price hasn't changed
-    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockUpdate).not.toHaveBeenCalled();
 
     // Verify getEffectivePriceCents was called with correct parameters
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp1',
-    })
-  })
+      clientId: "client1",
+      vendorProductId: "vp1",
+    });
+  });
 
-  it('should return diffs with one price decrease', async () => {
+  it("should return diffs with one price decrease", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
-    vi.mocked(getEffectivePriceCents).mockResolvedValue(800) // Price decreased
+    vi.mocked(getEffectivePriceCents).mockResolvedValue(800); // Price decreased
 
-    const mockUpdate = vi.fn()
+    const mockUpdate = vi.fn();
 
     // Mock cart query
     vi.mocked(prisma.cart.findFirst).mockResolvedValue({
-      id: 'cart1',
-      clientId: 'client1',
-      createdByUserId: 'user1',
-      status: 'ACTIVE',
+      id: "cart1",
+      clientId: "client1",
+      createdByUserId: "user1",
+      status: "ACTIVE",
       createdAt: new Date(),
       updatedAt: new Date(),
-      items: [
+      CartItem: [
         {
-          id: 'item1',
-          vendorProductId: 'vp1',
+          id: "item1",
+          vendorProductId: "vp1",
           unitPriceCents: 1000, // Old price
         },
       ],
-    } as any)
+    } as any);
 
     // Mock transaction
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
@@ -214,66 +226,68 @@ describe('recalcCartPricesForUser', () => {
         cartItem: {
           update: mockUpdate,
         },
-      }
-      return callback(tx)
-    })
+      };
+      return callback(tx);
+    });
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
-    expect(diffs).toHaveLength(1)
+    expect(diffs).toHaveLength(1);
     expect(diffs[0]).toEqual({
-      itemId: 'item1',
+      itemId: "item1",
       oldPriceCents: 1000,
       newPriceCents: 800,
-    })
+    });
 
     // Should update the cart item with new price
     expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'item1' },
+      where: { id: "item1" },
       data: {
         unitPriceCents: 800,
         updatedAt: expect.any(Date),
       },
-    })
+    });
 
     // Verify getEffectivePriceCents was called with correct parameters
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp1',
-    })
-  })
+      clientId: "client1",
+      vendorProductId: "vp1",
+    });
+  });
 
-  it('should return diffs with one price increase', async () => {
+  it("should return diffs with one price increase", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
-    vi.mocked(getEffectivePriceCents).mockResolvedValue(1200) // Price increased
+    vi.mocked(getEffectivePriceCents).mockResolvedValue(1200); // Price increased
 
-    const mockUpdate = vi.fn()
+    const mockUpdate = vi.fn();
 
     // Mock cart query
     vi.mocked(prisma.cart.findFirst).mockResolvedValue({
-      id: 'cart1',
-      clientId: 'client1',
-      createdByUserId: 'user1',
-      status: 'ACTIVE',
+      id: "cart1",
+      clientId: "client1",
+      createdByUserId: "user1",
+      status: "ACTIVE",
       createdAt: new Date(),
       updatedAt: new Date(),
-      items: [
+      CartItem: [
         {
-          id: 'item1',
-          vendorProductId: 'vp1',
+          id: "item1",
+          vendorProductId: "vp1",
           unitPriceCents: 1000, // Old price
         },
       ],
-    } as any)
+    } as any);
 
     // Mock transaction
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
@@ -281,80 +295,82 @@ describe('recalcCartPricesForUser', () => {
         cartItem: {
           update: mockUpdate,
         },
-      }
-      return callback(tx)
-    })
+      };
+      return callback(tx);
+    });
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
-    expect(diffs).toHaveLength(1)
+    expect(diffs).toHaveLength(1);
     expect(diffs[0]).toEqual({
-      itemId: 'item1',
+      itemId: "item1",
       oldPriceCents: 1000,
       newPriceCents: 1200,
-    })
+    });
 
     // Should update the cart item with new price
     expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'item1' },
+      where: { id: "item1" },
       data: {
         unitPriceCents: 1200,
         updatedAt: expect.any(Date),
       },
-    })
+    });
 
     // Verify getEffectivePriceCents was called with correct parameters
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp1',
-    })
-  })
+      clientId: "client1",
+      vendorProductId: "vp1",
+    });
+  });
 
-  it('should handle multiple items with mixed price changes', async () => {
+  it("should handle multiple items with mixed price changes", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
     // Mock different prices for different products
     vi.mocked(getEffectivePriceCents)
       .mockResolvedValueOnce(800) // item1: decreased
       .mockResolvedValueOnce(1500) // item2: increased
-      .mockResolvedValueOnce(2000) // item3: unchanged
+      .mockResolvedValueOnce(2000); // item3: unchanged
 
-    const mockUpdate = vi.fn()
+    const mockUpdate = vi.fn();
 
     // Mock cart query
     vi.mocked(prisma.cart.findFirst).mockResolvedValue({
-      id: 'cart1',
-      clientId: 'client1',
-      createdByUserId: 'user1',
-      status: 'ACTIVE',
+      id: "cart1",
+      clientId: "client1",
+      createdByUserId: "user1",
+      status: "ACTIVE",
       createdAt: new Date(),
       updatedAt: new Date(),
-      items: [
+      CartItem: [
         {
-          id: 'item1',
-          vendorProductId: 'vp1',
+          id: "item1",
+          vendorProductId: "vp1",
           unitPriceCents: 1000, // Will decrease to 800
         },
         {
-          id: 'item2',
-          vendorProductId: 'vp2',
+          id: "item2",
+          vendorProductId: "vp2",
           unitPriceCents: 1000, // Will increase to 1500
         },
         {
-          id: 'item3',
-          vendorProductId: 'vp3',
+          id: "item3",
+          vendorProductId: "vp3",
           unitPriceCents: 2000, // Will stay 2000
         },
       ],
-    } as any)
+    } as any);
 
     // Mock transaction
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
@@ -362,100 +378,102 @@ describe('recalcCartPricesForUser', () => {
         cartItem: {
           update: mockUpdate,
         },
-      }
-      return callback(tx)
-    })
+      };
+      return callback(tx);
+    });
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
-    expect(diffs).toHaveLength(3)
+    expect(diffs).toHaveLength(3);
     expect(diffs[0]).toEqual({
-      itemId: 'item1',
+      itemId: "item1",
       oldPriceCents: 1000,
       newPriceCents: 800,
-    })
+    });
     expect(diffs[1]).toEqual({
-      itemId: 'item2',
+      itemId: "item2",
       oldPriceCents: 1000,
       newPriceCents: 1500,
-    })
+    });
     expect(diffs[2]).toEqual({
-      itemId: 'item3',
+      itemId: "item3",
       oldPriceCents: 2000,
       newPriceCents: 2000,
-    })
+    });
 
     // Should update only items with changed prices (item1 and item2)
-    expect(mockUpdate).toHaveBeenCalledTimes(2)
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
     expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'item1' },
+      where: { id: "item1" },
       data: {
         unitPriceCents: 800,
         updatedAt: expect.any(Date),
       },
-    })
+    });
     expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'item2' },
+      where: { id: "item2" },
       data: {
         unitPriceCents: 1500,
         updatedAt: expect.any(Date),
       },
-    })
+    });
 
     // Verify getEffectivePriceCents was called with correct parameters for each item
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp1',
-    })
+      clientId: "client1",
+      vendorProductId: "vp1",
+    });
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp2',
-    })
+      clientId: "client1",
+      vendorProductId: "vp2",
+    });
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp3',
-    })
-  })
+      clientId: "client1",
+      vendorProductId: "vp3",
+    });
+  });
 
-  it('should correctly compute totals after recalculation', async () => {
+  it("should correctly compute totals after recalculation", async () => {
     vi.mocked(currentUser).mockResolvedValue({
-      id: 'user1',
-      email: 'client@test.com',
-      role: 'CLIENT',
-      clientId: 'client1',
-      name: 'Client',
+      id: "user1",
+      email: "client@test.com",
+      role: "CLIENT",
+      clientId: "client1",
+      name: "Client",
       agentCode: null,
       vendorId: null,
-    })
+      driverId: null,
+      status: "APPROVED",
+    });
 
     // All prices decrease
     vi.mocked(getEffectivePriceCents)
       .mockResolvedValueOnce(900) // item1: 1000 -> 900
-      .mockResolvedValueOnce(1800) // item2: 2000 -> 1800
+      .mockResolvedValueOnce(1800); // item2: 2000 -> 1800
 
-    const mockUpdate = vi.fn()
+    const mockUpdate = vi.fn();
 
     // Mock cart query
     vi.mocked(prisma.cart.findFirst).mockResolvedValue({
-      id: 'cart1',
-      clientId: 'client1',
-      createdByUserId: 'user1',
-      status: 'ACTIVE',
+      id: "cart1",
+      clientId: "client1",
+      createdByUserId: "user1",
+      status: "ACTIVE",
       createdAt: new Date(),
       updatedAt: new Date(),
-      items: [
+      CartItem: [
         {
-          id: 'item1',
-          vendorProductId: 'vp1',
+          id: "item1",
+          vendorProductId: "vp1",
           unitPriceCents: 1000,
         },
         {
-          id: 'item2',
-          vendorProductId: 'vp2',
+          id: "item2",
+          vendorProductId: "vp2",
           unitPriceCents: 2000,
         },
       ],
-    } as any)
+    } as any);
 
     // Mock transaction
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
@@ -463,29 +481,29 @@ describe('recalcCartPricesForUser', () => {
         cartItem: {
           update: mockUpdate,
         },
-      }
-      return callback(tx)
-    })
+      };
+      return callback(tx);
+    });
 
-    const diffs = await recalcCartPricesForUser()
+    const diffs = await recalcCartPricesForUser();
 
     // Calculate total savings
-    const totalOld = diffs.reduce((sum, diff) => sum + diff.oldPriceCents, 0)
-    const totalNew = diffs.reduce((sum, diff) => sum + diff.newPriceCents, 0)
-    const savings = totalOld - totalNew
+    const totalOld = diffs.reduce((sum, diff) => sum + diff.oldPriceCents, 0);
+    const totalNew = diffs.reduce((sum, diff) => sum + diff.newPriceCents, 0);
+    const savings = totalOld - totalNew;
 
-    expect(totalOld).toBe(3000) // 1000 + 2000
-    expect(totalNew).toBe(2700) // 900 + 1800
-    expect(savings).toBe(300) // 10% average discount
+    expect(totalOld).toBe(3000); // 1000 + 2000
+    expect(totalNew).toBe(2700); // 900 + 1800
+    expect(savings).toBe(300); // 10% average discount
 
     // Verify getEffectivePriceCents was called with correct parameters for each item
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp1',
-    })
+      clientId: "client1",
+      vendorProductId: "vp1",
+    });
     expect(getEffectivePriceCents).toHaveBeenCalledWith({
-      clientId: 'client1',
-      vendorProductId: 'vp2',
-    })
-  })
-})
+      clientId: "client1",
+      vendorProductId: "vp2",
+    });
+  });
+});

--- a/tests/catalog/catalog-filters.test.tsx
+++ b/tests/catalog/catalog-filters.test.tsx
@@ -27,14 +27,14 @@ describe("CatalogFilters", () => {
     vi.clearAllMocks();
     // Reset search params by creating a new instance
     Object.keys(mockSearchParams).forEach((key) =>
-      mockSearchParams.delete(key)
+      mockSearchParams.delete(key),
     );
     (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
       replace: mockReplace,
       refresh: vi.fn(),
     });
     (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
-      mockSearchParams
+      mockSearchParams,
     );
   });
 
@@ -43,10 +43,10 @@ describe("CatalogFilters", () => {
 
     expect(screen.getByLabelText("Search products")).toBeInTheDocument();
     expect(
-      screen.getByText("Products supplied by multiple trusted vendors")
+      screen.getByText("Products supplied by multiple trusted vendors"),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText("Show in-stock products only")
+      screen.getByLabelText("Show in-stock products only"),
     ).toBeInTheDocument();
   });
 
@@ -64,10 +64,10 @@ describe("CatalogFilters", () => {
     await waitFor(
       () => {
         expect(mockReplace).toHaveBeenCalledWith(
-          expect.stringContaining("q=pasta")
+          expect.stringContaining("q=pasta"),
         );
       },
-      { timeout: 500 }
+      { timeout: 500 },
     );
   });
 
@@ -77,6 +77,12 @@ describe("CatalogFilters", () => {
       ...defaultProps,
       initial: { ...defaultProps.initial, q: "pasta" },
     };
+
+    // Sync mock searchParams with initial props so useEffect doesn't override state
+    const searchParamsWithQ = new URLSearchParams("q=pasta");
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      searchParamsWithQ,
+    );
 
     render(<CatalogFilters {...propsWithSearch} />);
 
@@ -89,7 +95,7 @@ describe("CatalogFilters", () => {
           mockReplace.mock.calls[mockReplace.mock.calls.length - 1];
         expect(lastCall[0]).not.toContain("q=");
       },
-      { timeout: 500 }
+      { timeout: 500 },
     );
   });
 
@@ -101,7 +107,7 @@ describe("CatalogFilters", () => {
     await user.click(checkbox);
 
     expect(mockReplace).toHaveBeenCalledWith(
-      expect.stringContaining("inStock=1")
+      expect.stringContaining("inStock=1"),
     );
   });
 
@@ -111,6 +117,11 @@ describe("CatalogFilters", () => {
       ...defaultProps,
       initial: { ...defaultProps.initial, inStock: true },
     };
+
+    const searchParamsWithInStock = new URLSearchParams("inStock=1");
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      searchParamsWithInStock,
+    );
 
     render(<CatalogFilters {...propsWithInStock} />);
 
@@ -132,6 +143,11 @@ describe("CatalogFilters", () => {
       },
     };
 
+    const searchParamsWithFilters = new URLSearchParams("q=pasta&inStock=1");
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      searchParamsWithFilters,
+    );
+
     render(<CatalogFilters {...propsWithFilters} />);
 
     expect(screen.getByText(/Search: pasta/)).toBeInTheDocument();
@@ -149,6 +165,11 @@ describe("CatalogFilters", () => {
         inStock: true,
       },
     };
+
+    const searchParamsWithFilters = new URLSearchParams("q=pasta&inStock=1");
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      searchParamsWithFilters,
+    );
 
     render(<CatalogFilters {...propsWithFilters} />);
 


### PR DESCRIPTION
## Summary
- Fix 40 pre-existing test failures across 8 test files caused by schema changes from the onboarding epic (#142) and VAT/fees features
- Add missing `status`, `driverId` fields to mock user objects across all test files
- Rename camelCase Prisma relations to PascalCase (`items`→`CartItem`, `vendorProduct`→`VendorProduct`, etc.)
- Update `order-history` mocks for `OrderItem`/`SubOrder` select changes
- Add `SubOrder`/`stripe-auth` mocks to admin-orders tests
- Update nav test expectations for current nav item counts and labels
- Fix `order-vat` fee expectations (fee computed on `netTotalCents`, not `grossTotalCents`)
- Fix `catalog-filters` mock `searchParams` to match initial props (prevents `useEffect` override)
- Rewrite `create-order-from-cart` test with VAT/fees/SubOrder mocks

## Test plan
- [x] `npx vitest run` — 291 passed, 0 failed across 22 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)